### PR TITLE
Add's rtype to all constants used in P3 to ensure precision consistency 

### DIFF
--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -252,6 +252,7 @@ contains
     ! the lookup table is two dimensional as a function of number-weighted mean size
     ! proportional to qr/Nr and shape parameter mu_r
 
+!ASD rtype problem for mu_r loop
     mu_r_loop: do ii = 1,10   !** change 10 to 9, since range of mu_r is 0-8  CONFIRM
        !mu_r_loop: do ii = 1,9   !** change 10 to 9, since range of mu_r is 0-8
 
@@ -554,53 +555,53 @@ contains
 
     !PMC deleted 'threshold size difference' calculation for multicategory here
 
-    deltaD_init = 999.    !not used if n_iceCat=1 (but should be defined)
+    deltaD_init = 999._rtype    !not used if n_iceCat=1 (but should be defined)
 
     ! Note:  Code for prediction of supersaturation is available in current version.
     !        In the future 'log_predictSsat' will be a user-defined namelist key.
     log_predictSsat = .false.
 
-    inv_dzq    = 1./dzq  ! inverse of thickness of layers
-    odt        = 1./dt   ! inverse model time step
+    inv_dzq    = 1._rtype/dzq  ! inverse of thickness of layers
+    odt        = 1._rtype/dt   ! inverse model time step
 
     ! Compute time scale factor over which to apply soft rain lambda limiter
     ! note: '1./max(30.,dt)' = '1.*min(1./30., 1./dt)'
-    timeScaleFactor = min(1./120., odt)
+    timeScaleFactor = min(1._rtype/120._rtype, odt)
 
-    prt_liq   = 0.
-    prt_sol   = 0.
-    pratot    = 0.
-    prctot    = 0.
-    prec      = 0.
-    mu_r      = 0.
-    diag_ze   = -99.
-    diam_ice  = 0.
-    ze_ice    = 1.e-22
-    ze_rain   = 1.e-22
-    diag_effc = 10.e-6 ! default value
+    prt_liq   = 0._rtype
+    prt_sol   = 0._rtype
+    pratot    = 0._rtype
+    prctot    = 0._rtype
+    prec      = 0._rtype
+    mu_r      = 0._rtype
+    diag_ze   = -99._rtype
+    diam_ice  = 0._rtype
+    ze_ice    = 1.e-22_rtype
+    ze_rain   = 1.e-22_rtype
+    diag_effc = 10.e-6_rtype ! default value
     !diag_effr = 25.e-6 ! default value
-    diag_effi = 25.e-6 ! default value
-    diag_vmi  = 0.
-    diag_di   = 0.
-    diag_rhoi = 0.
-    rhorime_c = 400.
+    diag_effi = 25.e-6_rtype ! default value
+    diag_vmi  = 0._rtype
+    diag_di   = 0._rtype
+    diag_rhoi = 0._rtype
+    rhorime_c = 400._rtype
 
-    cmeiout = 0.
-    prain   = 0.
-    nevapr  = 0.
-    rflx    = 0.
-    sflx    = 0.
-    p3_tend_out = 0.
+    cmeiout = 0._rtype
+    prain   = 0._rtype
+    nevapr  = 0._rtype
+    rflx    = 0._rtype
+    sflx    = 0._rtype
+    p3_tend_out = 0._rtype
 
     inv_icldm = 1.0_rtype/icldm
     inv_lcldm = 1.0_rtype/lcldm
     inv_rcldm = 1.0_rtype/rcldm
     ! AaronDonahue added exner term to replace all instances of th(i,k)/t(i,k), since th(i,k) is updated but t(i,k) is not, and this was
     ! causing energy conservation errors.
-    inv_exner = 1./exner        !inverse of Exner expression, used when converting potential temp to temp
+    inv_exner = 1._rtype/exner        !inverse of Exner expression, used when converting potential temp to temp
     t       = th    *inv_exner    !compute temperature from theta (value at beginning of microphysics step)
     t_old   = th_old*inv_exner    !compute temperature from theta (value at beginning of model time step)
-    qv      = max(qv,0.)        !clip water vapor to prevent negative values passed in (beginning of microphysics)
+    qv      = max(qv,0._rtype)        !clip water vapor to prevent negative values passed in (beginning of microphysics)
     ! AaronDonahue added this load of latent heat to be consistent with E3SM, since the inconsistentcy was causing water conservation errors.
     call get_latent_heat(its,ite,kts,kte,xxlv,xxls,xlf)
     !==
@@ -629,75 +630,75 @@ contains
             !heat is determined by calling a p3_util function so that it
             !can be made consistent with E3SM definition of latent heat
           rho(i,k)     = pdel(i,k)/dzq(i,k)/g  ! pres(i,k)/(rd*t(i,k))
-          inv_rho(i,k) = 1./rho(i,k)
+          inv_rho(i,k) = 1._rtype/rho(i,k)
           qvs(i,k)     = qv_sat(t_old(i,k),pres(i,k),0)
           qvi(i,k)     = qv_sat(t_old(i,k),pres(i,k),1)
 
           ! if supersaturation is not predicted or during the first time step, then diagnose from qv and T (qvs)
           if (.not.(log_predictSsat).or.it.eq.1) then
              ssat(i,k)    = qv_old(i,k)-qvs(i,k)
-             sup(i,k)     = qv_old(i,k)/qvs(i,k)-1.
-             supi(i,k)    = qv_old(i,k)/qvi(i,k)-1.
+             sup(i,k)     = qv_old(i,k)/qvs(i,k)-1._rtype
+             supi(i,k)    = qv_old(i,k)/qvi(i,k)-1._rtype
              ! if supersaturation is predicted then diagnose sup and supi from ssat
           else if ((log_predictSsat).and.it.gt.1) then
              sup(i,k)     = ssat(i,k)/qvs(i,k)
              supi(i,k)    = (ssat(i,k)+qvs(i,k)-qvi(i,k))/qvi(i,k)
           endif
 
-          rhofacr(i,k) = (rhosur*inv_rho(i,k))**0.54
-          rhofaci(i,k) = (rhosui*inv_rho(i,k))**0.54
-          dum          = 1.496e-6*t(i,k)**1.5/(t(i,k)+120.)  ! this is mu
-          acn(i,k)     = g*rhow/(18.*dum)  ! 'a' parameter for droplet fallspeed (Stokes' law)
+          rhofacr(i,k) = (rhosur*inv_rho(i,k))**0.54_rtype
+          rhofaci(i,k) = (rhosui*inv_rho(i,k))**0.54_rtype
+          dum          = 1.496e-6_rtype*t(i,k)**1.5_rtype/(t(i,k)+120._rtype)  ! this is mu
+          acn(i,k)     = g*rhow/(18._rtype*dum)  ! 'a' parameter for droplet fallspeed (Stokes' law)
 
           !specify cloud droplet number (for 1-moment version)
           if (.not.(log_predictNc)) then
              nc(i,k) = nccnst*inv_rho(i,k)
           endif
 
-          if ((t(i,k).lt.zerodegc .and. supi(i,k).ge.-0.05) .or.                              &
-               (t(i,k).ge.zerodegc .and. sup(i,k).ge.-0.05 )) log_nucleationPossible = .true.
+          if ((t(i,k).lt.zerodegc .and. supi(i,k).ge.-0.05_rtype) .or.                              &
+               (t(i,k).ge.zerodegc .and. sup(i,k).ge.-0.05_rtype )) log_nucleationPossible = .true.
 
           !--- apply mass clipping if dry and mass is sufficiently small
           !    (implying all mass is expected to evaporate/sublimate in one time step)
 
-          if (qc(i,k).lt.qsmall .or. (qc(i,k).lt.1.e-8 .and. sup(i,k).lt.-0.1)) then
+          if (qc(i,k).lt.qsmall .or. (qc(i,k).lt.1.e-8_rtype .and. sup(i,k).lt.-0.1_rtype)) then
              qv(i,k) = qv(i,k) + qc(i,k)
              th(i,k) = th(i,k) - exner(i,k)*qc(i,k)*xxlv(i,k)*inv_cp
-             qc(i,k) = 0.
-             nc(i,k) = 0.
+             qc(i,k) = 0._rtype
+             nc(i,k) = 0._rtype
           else
              log_hydrometeorsPresent = .true.    ! updated further down
           endif
 
-          if (qr(i,k).lt.qsmall .or. (qr(i,k).lt.1.e-8 .and. sup(i,k).lt.-0.1)) then
+          if (qr(i,k).lt.qsmall .or. (qr(i,k).lt.1.e-8_rtype .and. sup(i,k).lt.-0.1_rtype)) then
              qv(i,k) = qv(i,k) + qr(i,k)
              th(i,k) = th(i,k) - exner(i,k)*qr(i,k)*xxlv(i,k)*inv_cp
-             qr(i,k) = 0.
-             nr(i,k) = 0.
+             qr(i,k) = 0._rtype
+             nr(i,k) = 0._rtype
           else
              log_hydrometeorsPresent = .true.    ! updated further down
           endif
 
-          if (qitot(i,k).lt.qsmall .or. (qitot(i,k).lt.1.e-8 .and.             &
-               supi(i,k).lt.-0.1)) then
+          if (qitot(i,k).lt.qsmall .or. (qitot(i,k).lt.1.e-8_rtype .and.             &
+               supi(i,k).lt.-0.1_rtype)) then
              qv(i,k) = qv(i,k) + qitot(i,k)
              th(i,k) = th(i,k) - exner(i,k)*qitot(i,k)*xxls(i,k)*inv_cp
-             qitot(i,k) = 0.
-             nitot(i,k) = 0.
-             qirim(i,k) = 0.
-             birim(i,k) = 0.
+             qitot(i,k) = 0._rtype
+             nitot(i,k) = 0._rtype
+             qirim(i,k) = 0._rtype
+             birim(i,k) = 0._rtype
           else
              log_hydrometeorsPresent = .true.    ! final update
           endif
 
-          if (qitot(i,k).ge.qsmall .and. qitot(i,k).lt.1.e-8 .and.             &
+          if (qitot(i,k).ge.qsmall .and. qitot(i,k).lt.1.e-8_rtype .and.             &
                t(i,k).ge.zerodegc) then
              qr(i,k) = qr(i,k) + qitot(i,k)
              th(i,k) = th(i,k) - exner(i,k)*qitot(i,k)*xlf(i,k)*inv_cp
-             qitot(i,k) = 0.
-             nitot(i,k) = 0.
-             qirim(i,k) = 0.
-             birim(i,k) = 0.
+             qitot(i,k) = 0._rtype
+             nitot(i,k) = 0._rtype
+             qirim(i,k) = 0._rtype
+             birim(i,k) = 0._rtype
           endif
 
 
@@ -736,27 +737,27 @@ contains
           if (qitot(i,k).ge.qsmall) log_exitlevel = .false.
           !enddo
           if (log_exitlevel .and.                                                           &
-               ((t(i,k).lt.zerodegc .and. supi(i,k).lt.-0.05) .or.                              &
-               (t(i,k).ge.zerodegc .and. sup(i,k) .lt.-0.05))) goto 555   !i.e. skip all process rates
+               ((t(i,k).lt.zerodegc .and. supi(i,k).lt.-0.05_rtype) .or.                              &
+               (t(i,k).ge.zerodegc .and. sup(i,k) .lt.-0.05_rtype))) goto 555   !i.e. skip all process rates
 
           ! All microphysics tendencies will be computed as IN-CLOUD, they will be mapped back to cell-average later.
 
           ! initialize warm-phase process rates
-          qcacc   = 0.;     qrevp   = 0.;     qccon   = 0.
-          qcaut   = 0.;     qcevp   = 0.;     qrcon   = 0.
-          ncacc   = 0.;     ncnuc   = 0.;     ncslf   = 0.
-          ncautc  = 0.;     qcnuc   = 0.;     nrslf   = 0.
-          nrevp   = 0.;     ncautr  = 0.
+          qcacc   = 0._rtype;     qrevp   = 0._rtype;     qccon   = 0._rtype
+          qcaut   = 0._rtype;     qcevp   = 0._rtype;     qrcon   = 0._rtype
+          ncacc   = 0._rtype;     ncnuc   = 0._rtype;     ncslf   = 0._rtype
+          ncautc  = 0._rtype;     qcnuc   = 0._rtype;     nrslf   = 0._rtype
+          nrevp   = 0._rtype;     ncautr  = 0._rtype
 
           ! initialize ice-phase  process rates
-          qisub   = 0.;     nrshdr  = 0.
-          qcheti  = 0.;     qrcol   = 0.;     qcshd   = 0.
-          qimlt   = 0.;     qccol   = 0.
-          qrheti  = 0.;     qinuc   = 0.;     nimlt   = 0.
-          nccol   = 0.;     ncshdc  = 0.
-          ncheti  = 0.;     nrcol   = 0.;     nislf   = 0.
-          ninuc   = 0.;     qidep   = 0.
-          nrheti  = 0.;     nisub   = 0.;     qwgrth  = 0.
+          qisub   = 0._rtype;     nrshdr  = 0._rtype
+          qcheti  = 0._rtype;     qrcol   = 0._rtype;     qcshd   = 0._rtype
+          qimlt   = 0._rtype;     qccol   = 0._rtype
+          qrheti  = 0._rtype;     qinuc   = 0._rtype;     nimlt   = 0._rtype
+          nccol   = 0._rtype;     ncshdc  = 0._rtype
+          ncheti  = 0._rtype;     nrcol   = 0._rtype;     nislf   = 0._rtype
+          ninuc   = 0._rtype;     qidep   = 0._rtype
+          nrheti  = 0._rtype;     nisub   = 0._rtype;     qwgrth  = 0._rtype
  
           ! initialize microphysics processes tendency output
           p3_tend_out(i,k,42) = qc(i,k)    ! Liq. microphysics tendency, initialize 
@@ -780,16 +781,16 @@ contains
              ! scale mixing and radiation are not explicitly included.
 
              dqsdt   = xxlv(i,k)*qvs(i,k)/(rv*t(i,k)*t(i,k))
-             ab      = 1. + dqsdt*xxlv(i,k)*inv_cp
+             ab      = 1._rtype + dqsdt*xxlv(i,k)*inv_cp
              epsilon = (qv(i,k)-qvs(i,k)-ssat(i,k))/ab
              epsilon = max(epsilon,-qc(i,k))   ! limit adjustment to available water
              ! don't adjust upward if subsaturated
              ! otherwise this could result in positive adjustment
              ! (spurious generation ofcloud water) in subsaturated conditions
-             if (ssat(i,k).lt.0.) epsilon = min(0.,epsilon)
+             if (ssat(i,k).lt.0._rtype) epsilon = min(0._rtype,epsilon)
 
              ! now do the adjustment
-             if (abs(epsilon).ge.1.e-15) then
+             if (abs(epsilon).ge.1.e-15_rtype) then
                 qc(i,k)   = qc(i,k)+epsilon
                 qc_incld(i,k)   = qc(i,k)*inv_lcldm(i,k)
                 qv(i,k)   = qv(i,k)-epsilon
@@ -798,8 +799,8 @@ contains
                 t(i,k)    = th(i,k)*inv_exner(i,k) !*(1.e-5*pres(i,k))**(rd*inv_cp)
                 qvs(i,k)  = qv_sat(t(i,k),pres(i,k),0)
                 qvi(i,k)  = qv_sat(t(i,k),pres(i,k),1)
-                sup(i,k)  = qv(i,k)/qvs(i,k)-1.
-                supi(i,k) = qv(i,k)/qvi(i,k)-1.
+                sup(i,k)  = qv(i,k)/qvs(i,k)-1._rtype
+                supi(i,k) = qv(i,k)/qvi(i,k)-1._rtype
                 ssat(i,k) = qv(i,k)-qvs(i,k)
              endif
 
@@ -813,22 +814,22 @@ contains
           if (log_exitlevel) goto 444   !i.e. skip to nucleation
 
           !time/space varying physical variables
-          mu     = 1.496e-6*t(i,k)**1.5/(t(i,k)+120.)
-          dv     = 8.794e-5*t(i,k)**1.81/pres(i,k)
+          mu     = 1.496e-6_rtype*t(i,k)**1.5_rtype/(t(i,k)+120._rtype)
+          dv     = 8.794e-5_rtype*t(i,k)**1.81_rtype/pres(i,k)
           sc     = mu/(rho(i,k)*dv)
-          dum    = 1./(rv*t(i,k)**2)
+          dum    = 1._rtype/(rv*t(i,k)**2)
           dqsdt  = xxlv(i,k)*qvs(i,k)*dum
           dqsidt = xxls(i,k)*qvi(i,k)*dum
-          ab     = 1.+dqsdt*xxlv(i,k)*inv_cp
-          abi    = 1.+dqsidt*xxls(i,k)*inv_cp
-          kap    = 1.414e+3*mu
+          ab     = 1._rtype+dqsdt*xxlv(i,k)*inv_cp
+          abi    = 1._rtype+dqsidt*xxls(i,k)*inv_cp
+          kap    = 1.414e+3_rtype*mu
           ! very simple temperature dependent aggregation efficiency
-          if (t(i,k).lt.253.15) then
-             eii=0.1
-          else if (t(i,k).ge.253.15.and.t(i,k).lt.268.15) then
-             eii=0.1+(t(i,k)-253.15)/15.*0.9  ! linear ramp from 0.1 to 1 between 253.15 and 268.15 K
+          if (t(i,k).lt.253.15_rtype) then
+             eii=0.1_rtype
+          else if (t(i,k).ge.253.15_rtype.and.t(i,k).lt.268.15_rtype) then
+             eii=0.1_rtype+(t(i,k)-253.15_rtype)/15._rtype*0.9_rtype  ! linear ramp from 0.1 to 1 between 253.15 and 268.15 K
           else
-             eii=1.
+             eii=1._rtype
           end if
 
           call get_cloud_dsd2(qc_incld(i,k),nc_incld(i,k),mu_c(i,k),rho(i,k),nu(i,k),dnu,lamc(i,k),     &
@@ -840,7 +841,7 @@ contains
           nr(i,k) = nr_incld(i,k)*rcldm(i,k)
 
           ! initialize inverse supersaturation relaxation timescale for combined ice categories
-          epsi_tot = 0.
+          epsi_tot = 0._rtype
 
           call impose_max_total_Ni(nitot_incld(i,k),max_total_Ni,inv_rho(i,k))
 
@@ -848,11 +849,11 @@ contains
 
              !impose lower limits to prevent taking log of # < 0
              nitot_incld(i,k) = max(nitot_incld(i,k),nsmall)
-             nr_incld(i,k)         = max(nr_incld(i,k),nsmall)
+             nr_incld(i,k)    = max(nr_incld(i,k),nsmall)
 
              !compute mean-mass ice diameters (estimated; rigorous approach to be implemented later)
-             dum2 = 500. !ice density
-             diam_ice(i,k) = ((qitot_incld(i,k)*6.)/(nitot_incld(i,k)*dum2*pi))**thrd
+             dum2 = 500._rtype !ice density
+             diam_ice(i,k) = ((qitot_incld(i,k)*6._rtype)/(nitot_incld(i,k)*dum2*pi))**thrd
 
              call calc_bulkRhoRime(qitot_incld(i,k),qirim_incld(i,k),birim_incld(i,k),rhop)
 
@@ -878,8 +879,8 @@ contains
                 call access_lookup_table_coll(dumjj,dumii,dumj,dumi,1,dum1,dum3,dum4,dum5,f1pr07)
                 call access_lookup_table_coll(dumjj,dumii,dumj,dumi,2,dum1,dum3,dum4,dum5,f1pr08)
              else
-                f1pr07 = 0.
-                f1pr08 = 0.
+                f1pr07 = 0._rtype
+                f1pr08 = 0._rtype
              endif
 
              ! adjust Ni if needed to make sure mean size is in bounds (i.e. apply lambda limiters)
@@ -892,18 +893,18 @@ contains
              ! Determine additional collection efficiency factor to be applied to ice-ice collection.
              ! The computed values of qicol and nicol are multipiled by Eii_fact to gradually shut off collection
              ! if ice is highly rimed.
-             if (qirim_incld(i,k)>0.) then
+             if (qirim_incld(i,k)>0._rtype) then
                 tmp1 = qirim_incld(i,k)/qitot_incld(i,k)   !rime mass fraction
-                if (tmp1.lt.0.6) then
-                   Eii_fact=1.
-                else if (tmp1.ge.0.6.and.tmp1.lt.0.9) then
+                if (tmp1.lt.0.6_rtype) then
+                   Eii_fact=1._rtype
+                else if (tmp1.ge.0.6_rtype.and.tmp1.lt.0.9_rtype) then
                    ! linear ramp from 1 to 0 for Fr between 0.6 and 0.9
-                   Eii_fact = 1.-(tmp1-0.6)/0.3
+                   Eii_fact = 1._rtype-(tmp1-0.6_rtype)/0.3_rtype
                 else
-                   Eii_fact = 0.
+                   Eii_fact = 0._rtype
                 endif
              else
-                Eii_fact = 1.
+                Eii_fact = 1._rtype
              endif
 
           endif   ! qitot > qsmall
@@ -936,7 +937,7 @@ contains
              qcshd = rhofaci(i,k)*f1pr04*qc_incld(i,k)*eci*rho(i,k)*nitot_incld(i,k)
              nccol = rhofaci(i,k)*f1pr04*nc_incld(i,k)*eci*rho(i,k)*nitot_incld(i,k)
              ! source for rain number, assume 1 mm drops are shed
-             ncshdc = qcshd*1.923e+6
+             ncshdc = qcshd*1.923e+6_rtype
           endif
 
           !....................
@@ -954,8 +955,8 @@ contains
 
           if (qitot_incld(i,k).ge.qsmall .and. qr_incld(i,k).ge.qsmall .and. t(i,k).le.zerodegc) then
              ! note: f1pr08 and logn0r are already calculated as log_10
-             qrcol = 10.**(f1pr08+logn0r(i,k))*rho(i,k)*rhofaci(i,k)*eri*nitot_incld(i,k)
-             nrcol = 10.**(f1pr07+logn0r(i,k))*rho(i,k)*rhofaci(i,k)*eri*nitot_incld(i,k)
+             qrcol = 10._rtype**(f1pr08+logn0r(i,k))*rho(i,k)*rhofaci(i,k)*eri*nitot_incld(i,k)
+             nrcol = 10._rtype**(f1pr07+logn0r(i,k))*rho(i,k)*rhofaci(i,k)*eri*nitot_incld(i,k)
           endif
 
           ! for T > 273.15, assume collected rain number is shed as
@@ -966,9 +967,9 @@ contains
 
           if (qitot_incld(i,k).ge.qsmall .and. qr_incld(i,k).ge.qsmall .and. t(i,k).gt.zerodegc) then
              ! rain number sink due to collection
-             nrcol  = 10.**(f1pr07 + logn0r(i,k))*rho(i,k)*rhofaci(i,k)*eri*nitot_incld(i,k)
+             nrcol  = 10._rtype**(f1pr07 + logn0r(i,k))*rho(i,k)*rhofaci(i,k)*eri*nitot_incld(i,k)
              ! rain number source due to shedding = collected rain mass/mass of 1 mm drop
-             dum    = 10.**(f1pr08 + logn0r(i,k))*rho(i,k)*rhofaci(i,k)*eri*nitot_incld(i,k)
+             dum    = 10._rtype**(f1pr08 + logn0r(i,k))*rho(i,k)*rhofaci(i,k)*eri*nitot_incld(i,k)
              ! for now neglect shedding of ice collecting rain above freezing, since snow is
              ! not expected to shed in these conditions (though more hevaily rimed ice would be
              ! expected to lead to shedding)
@@ -1001,16 +1002,16 @@ contains
           ! note 'f1pr' values are normalized, so we need to multiply by N
 
           if (qitot_incld(i,k).ge.qsmall .and. t(i,k).gt.zerodegc) then
-             qsat0 = 0.622*e0/(pres(i,k)-e0)
+             qsat0 = 0.622_rtype*e0/(pres(i,k)-e0)
              !  dum=cpw/xlf(i,k)*(t(i,k)-273.15)*(pracsw1+qcshd)
              ! currently enhanced melting from collision is neglected
              ! dum=cpw/xlf(i,k)*(t(i,k)-273.15)*(pracsw1)
-             dum = 0.
+             dum = 0._rtype
              ! qimlt=(f1pr05+f1pr14*sc**0.3333*(rhofaci(i,k)*rho(i,k)/mu)**0.5)* &
              !       (t(i,k)-273.15)*2.*pi*kap/xlf(i,k)+dum
              ! include RH dependence
-             qimlt = ((f1pr05+f1pr14*sc**thrd*(rhofaci(i,k)*rho(i,k)/mu)**0.5)*((t(i,k)-   &
-                  zerodegc)*kap-rho(i,k)*xxlv(i,k)*dv*(qsat0-qv(i,k)))*2.*pi/xlf(i,k)+     &
+             qimlt = ((f1pr05+f1pr14*sc**thrd*(rhofaci(i,k)*rho(i,k)/mu)**0.5_rtype)*((t(i,k)-   &
+                  zerodegc)*kap-rho(i,k)*xxlv(i,k)*dv*(qsat0-qv(i,k)))*2._rtype*pi/xlf(i,k)+     &
                   dum)*nitot_incld(i,k)
              qimlt = max(qimlt,0.)
              nimlt = qimlt*(nitot_incld(i,k)/qitot_incld(i,k))
@@ -1022,19 +1023,19 @@ contains
           ! similar to Musil (1970), JAS
           ! note 'f1pr' values are normalized, so we need to multiply by N
 
-          if (qitot_incld(i,k).ge.qsmall .and. qc_incld(i,k)+qr_incld(i,k).ge.1.e-6 .and. t(i,k).lt.zerodegc) then
+          if (qitot_incld(i,k).ge.qsmall .and. qc_incld(i,k)+qr_incld(i,k).ge.1.e-6_rtype .and. t(i,k).lt.zerodegc) then
 
-             qsat0  = 0.622*e0/(pres(i,k)-e0)
-             qwgrth = ((f1pr05 + f1pr14*sc**thrd*(rhofaci(i,k)*rho(i,k)/mu)**0.5)*       &
-                  2.*pi*(rho(i,k)*xxlv(i,k)*dv*(qsat0-qv(i,k))-(t(i,k)-zerodegc)*           &
+             qsat0  = 0.622_rtype*e0/(pres(i,k)-e0)
+             qwgrth = ((f1pr05 + f1pr14*sc**thrd*(rhofaci(i,k)*rho(i,k)/mu)**0.5_rtype)*       &
+                  2._rtype*pi*(rho(i,k)*xxlv(i,k)*dv*(qsat0-qv(i,k))-(t(i,k)-zerodegc)*           &
                   kap)/(xlf(i,k)+cpw*(t(i,k)-zerodegc)))*nitot_incld(i,k)
-             qwgrth = max(qwgrth,0.)
+             qwgrth = max(qwgrth,0._rtype)
              !calculate shedding for wet growth
-             dum    = max(0.,(qccol+qrcol)-qwgrth)
-             if (dum.ge.1.e-10) then
-                nrshdr = nrshdr + dum*1.923e+6   ! 1/5.2e-7, 5.2e-7 is the mass of a 1 mm raindrop
-                if ((qccol+qrcol).ge.1.e-10) then
-                   dum1  = 1./(qccol+qrcol)
+             dum    = max(0._rtype,(qccol+qrcol)-qwgrth)
+             if (dum.ge.1.e-10_rtype) then
+                nrshdr = nrshdr + dum*1.923e+6_rtype   ! 1/5.2e-7, 5.2e-7 is the mass of a 1 mm raindrop
+                if ((qccol+qrcol).ge.1.e-10_rtype) then
+                   dum1  = 1._rtype/(qccol+qrcol)
                    qcshd = qcshd + dum*qccol*dum1
                    qccol = qccol - dum*qccol*dum1
                    qrcol = qrcol - dum*qrcol*dum1
@@ -1050,11 +1051,11 @@ contains
           ! calcualte total inverse ice relaxation timescale combined for all ice categories
           ! note 'f1pr' values are normalized, so we need to multiply by N
           if (qitot_incld(i,k).ge.qsmall .and. t(i,k).lt.zerodegc) then
-             epsi = ((f1pr05+f1pr14*sc**thrd*(rhofaci(i,k)*rho(i,k)/mu)**0.5)*2.*pi* &
+             epsi = ((f1pr05+f1pr14*sc**thrd*(rhofaci(i,k)*rho(i,k)/mu)**0.5_rtype)*2._rtype*pi* &
                   rho(i,k)*dv)*nitot_incld(i,k)
              epsi_tot   = epsi_tot + epsi
           else
-             epsi = 0.
+             epsi = 0._rtype
           endif
 
 
@@ -1078,33 +1079,33 @@ contains
 
              ! get mass-weighted mean ice fallspeed
              vtrmi1(i,k) = f1pr02*rhofaci(i,k)
-             iTc   = 1./min(-0.001,t(i,k)-zerodegc)
+             iTc   = 1._rtype/min(-0.001_rtype,t(i,k)-zerodegc)
 
              ! cloud:
              if (qc_incld(i,k).ge.qsmall) then
                 ! droplet fall speed
                 ! (use Stokes' formulation (thus use analytic solution)
-                Vt_qc(i,k) = acn(i,k)*gamma(4.+bcn+mu_c(i,k))/(lamc(i,k)**bcn*gamma(mu_c(i,k)+4.))
+                Vt_qc(i,k) = acn(i,k)*gamma(4._rtype+bcn+mu_c(i,k))/(lamc(i,k)**bcn*gamma(mu_c(i,k)+4._rtype))
                 ! use mass-weighted mean size
-                D_c = (mu_c(i,k)+4.)/lamc(i,k)
+                D_c = (mu_c(i,k)+4._rtype)/lamc(i,k)
                 V_impact  = abs(vtrmi1(i,k)-Vt_qc(i,k))
-                Ri        = -(0.5e+6*D_c)*V_impact*iTc
+                Ri        = -(0.5e+6_rtype*D_c)*V_impact*iTc
                 !               Ri        = max(1.,min(Ri,8.))
-                Ri        = max(1.,min(Ri,12.))
+                Ri        = max(1.,min(Ri,12._rtype))
                 if (Ri.le.8.) then
-                   rhorime_c  = (0.051 + 0.114*Ri - 0.0055*Ri**2)*1000.
+                   rhorime_c  = (0.051_rtype + 0.114_rtype*Ri - 0.0055_rtype*Ri**2)*1000._rtype
                 else
                    ! for Ri > 8 assume a linear fit between 8 and 12,
                    ! rhorime = 900 kg m-3 at Ri = 12
                    ! this is somewhat ad-hoc but allows a smoother transition
                    ! in rime density up to wet growth
-                   rhorime_c  = 611.+72.25*(Ri-8.)
+                   rhorime_c  = 611._rtype+72.25_rtype*(Ri-8._rtype)
                 endif
 
              endif    !if qc>qsmall
 
           else
-             rhorime_c = 400.
+             rhorime_c = 400._rtype
           endif ! qi > qsmall and T < 273.15
 
           !............................................................
@@ -1112,9 +1113,9 @@ contains
 
           if (qc_incld(i,k).ge.qsmall .and. t(i,k).le.rainfrze) then
              ! for future: calculate gamma(mu_c+4) in one place since its used multiple times  !AaronDonahue, TODO
-             dum   = (1./lamc(i,k))**3
-             Q_nuc = cons6*cdist1(i,k)*gamma(7.+mu_c(i,k))*exp(aimm*(zerodegc-t(i,k)))*dum**2
-             N_nuc = cons5*cdist1(i,k)*gamma(mu_c(i,k)+4.)*exp(aimm*(zerodegc-t(i,k)))*dum
+             dum   = (1._rtype/lamc(i,k))**3
+             Q_nuc = cons6*cdist1(i,k)*gamma(7._rtype+mu_c(i,k))*exp(aimm*(zerodegc-t(i,k)))*dum**2
+             N_nuc = cons5*cdist1(i,k)*gamma(mu_c(i,k)+4._rtype)*exp(aimm*(zerodegc-t(i,k)))*dum
              qcheti = Q_nuc
              ncheti = N_nuc
           endif
@@ -1125,9 +1126,9 @@ contains
           ! for future: get rid of log statements below for rain freezing
 
           if (qr_incld(i,k).ge.qsmall.and.t(i,k).le.rainfrze) then
-             Q_nuc = cons6*exp(log(cdistr(i,k))+log(gamma(7.+mu_r(i,k)))-6.*log(lamr(i,k)))* &
+             Q_nuc = cons6*exp(log(cdistr(i,k))+log(gamma(7._rtype+mu_r(i,k)))-6._rtype*log(lamr(i,k)))* &
                   exp(aimm*(zerodegc-T(i,k)))
-             N_nuc = cons5*exp(log(cdistr(i,k))+log(gamma(mu_r(i,k)+4.))-3.*log(lamr(i,k)))* &
+             N_nuc = cons5*exp(log(cdistr(i,k))+log(gamma(mu_r(i,k)+4._rtype))-3._rtype*log(lamr(i,k)))* &
                   exp(aimm*(zerodegc-T(i,k)))
              qrheti = Q_nuc
              nrheti = N_nuc
@@ -1165,26 +1166,26 @@ contains
              !final interpolation
              dum  = dum1+(rdumjj-real(dumjj))*(dum2-dum1)
 
-             epsr = 2.*pi*cdistr(i,k)*rho(i,k)*dv*(f1r*gamma(mu_r(i,k)+2.)/(lamr(i,k))+f2r*   &
-                  (rho(i,k)/mu)**0.5*sc**thrd*dum)
+             epsr = 2._rtype*pi*cdistr(i,k)*rho(i,k)*dv*(f1r*gamma(mu_r(i,k)+2._rtype)/(lamr(i,k))+f2r*   &
+                  (rho(i,k)/mu)**0.5_rtype*sc**thrd*dum)
           else
-             epsr = 0.
+             epsr = 0._rtype
           endif
 
           if (qc_incld(i,k).ge.qsmall) then
-             epsc = 2.*pi*rho(i,k)*dv*cdist(i,k)
+             epsc = 2._rtype*pi*rho(i,k)*dv*cdist(i,k)
           else
-             epsc = 0.
+             epsc = 0._rtype
           endif
           !===
 
           !PMC moved oabi outside t<273.15 loop. oabi is only *used* where t<273.15, but
           !t could be updated before oabi is used, resulting in unititialized use. Note
           !that t is not currently being updated before oabi is used, so this is just future-proofing.
-          oabi = 1./abi
+          oabi = 1._rtype/abi
           
           if (t(i,k).lt.zerodegc) then
-             xx   = epsc + epsr + epsi_tot*(1.+xxls(i,k)*inv_cp*dqsdt)*oabi
+             xx   = epsc + epsr + epsi_tot*(1._rtype+xxls(i,k)*inv_cp*dqsdt)*oabi
           else
              xx   = epsc + epsr
           endif
@@ -1220,13 +1221,13 @@ contains
 
           if (t(i,k).lt.zerodegc) then
              aaa = (qv(i,k)-qv_old(i,k))*odt - dqsdt*(-dum*g*inv_cp)-(qvs(i,k)-dumqvi)*     &
-                  (1.+xxls(i,k)*inv_cp*dqsdt)*oabi*epsi_tot
+                  (1._rtype+xxls(i,k)*inv_cp*dqsdt)*oabi*epsi_tot
           else
              aaa = (qv(i,k)-qv_old(i,k))*odt - dqsdt*(-dum*g*inv_cp)
           endif
 
-          xx  = max(1.e-20,xx)   ! set lower bound on xx to prevent division by zero
-          oxx = 1./xx
+          xx  = max(1.e-20_rtype,xx)   ! set lower bound on xx to prevent division by zero
+          oxx = 1._rtype/xx
 
           if (qc_incld(i,k).ge.qsmall) &
                qccon = (aaa*epsc*oxx+(ssat(i,k)-aaa*oxx)*odt*epsc*oxx*(1.-dexp(-dble(xx*dt))))/ab
@@ -1234,52 +1235,52 @@ contains
                qrcon = (aaa*epsr*oxx+(ssat(i,k)-aaa*oxx)*odt*epsr*oxx*(1.-dexp(-dble(xx*dt))))/ab
 
           !for very small water contents, evaporate instantly
-          if (sup(i,k).lt.-0.001 .and. qc_incld(i,k).lt.1.e-12)  qccon = -qc_incld(i,k)*odt
-          if (sup(i,k).lt.-0.001 .and. qr_incld(i,k).lt.1.e-12)  qrcon = -qr_incld(i,k)*odt
+          if (sup(i,k).lt.-0.001_rtype .and. qc_incld(i,k).lt.1.e-12_rtype)  qccon = -qc_incld(i,k)*odt
+          if (sup(i,k).lt.-0.001_rtype .and. qr_incld(i,k).lt.1.e-12_rtype)  qrcon = -qr_incld(i,k)*odt
 
-          if (qccon.lt.0.) then
+          if (qccon.lt.0._rtype) then
              qcevp = -qccon
-             qccon = 0.
+             qccon = 0._rtype
           endif
 
-          if (qrcon.lt.0.) then
+          if (qrcon.lt.0._rtype) then
              qrevp = -qrcon
              nrevp = qrevp*(nr_incld(i,k)/qr_incld(i,k))
              !nrevp = nrevp*exp(-0.2*mu_r(i,k))  !add mu dependence [Seifert (2008), neglecting size dependence]
-             qrcon = 0.
+             qrcon = 0._rtype
           endif
 
           !limit total condensation/evaporation to saturation adjustment
           dumqvs = qv_sat(t(i,k),pres(i,k),0)
-          qcon_satadj  = (qv(i,k)-dumqvs)/(1.+xxlv(i,k)**2*dumqvs/(cp*rv*t(i,k)**2))*odt
-          if (qccon+qrcon.gt.0.) then
-             ratio = max(0.,qcon_satadj)/(qccon+qrcon)
-             ratio = min(1.,ratio)
+          qcon_satadj  = (qv(i,k)-dumqvs)/(1._rtype+xxlv(i,k)**2*dumqvs/(cp*rv*t(i,k)**2))*odt
+          if (qccon+qrcon.gt.0._rtype) then
+             ratio = max(0._rtype,qcon_satadj)/(qccon+qrcon)
+             ratio = min(1._rtype,ratio)
              qccon = qccon*ratio
              qrcon = qrcon*ratio
-          elseif (qcevp+qrevp.gt.0.) then
-             ratio = max(0.,-qcon_satadj)/(qcevp+qrevp)
-             ratio = min(1.,ratio)
+          elseif (qcevp+qrevp.gt.0._rtype) then
+             ratio = max(0._rtype,-qcon_satadj)/(qcevp+qrevp)
+             ratio = min(1._rtype,ratio)
              qcevp = qcevp*ratio
              qrevp = qrevp*ratio
           endif
 
           if (qitot_incld(i,k).ge.qsmall.and.t(i,k).lt.zerodegc) then
              qidep = (aaa*epsi*oxx+(ssat(i,k)-aaa*oxx)*odt*epsi*oxx*   &
-                  (1.-dexp(-dble(xx*dt))))*oabi+(qvs(i,k)-dumqvi)*epsi*oabi
+                  (1._rtype-dexp(-dble(xx*dt))))*oabi+(qvs(i,k)-dumqvi)*epsi*oabi
           endif
 
           !for very small ice contents in dry air, sublimate all ice instantly
-          if (supi(i,k).lt.-0.001 .and. qitot_incld(i,k).lt.1.e-12) &
+          if (supi(i,k).lt.-0.001_rtype .and. qitot_incld(i,k).lt.1.e-12_rtype) &
                qidep = -qitot_incld(i,k)*odt
 
-          if (qidep.lt.0.) then
+          if (qidep.lt.0._rtype) then
              !note: limit to saturation adjustment (for dep and subl) is applied later
              qisub = -qidep
              qisub = qisub*clbfact_sub
              qisub = min(qisub, qitot_incld(i,k)*dt)
              nisub = qisub*(nitot_incld(i,k)/qitot_incld(i,k))
-             qidep = 0.
+             qidep = 0._rtype
           else
              qidep = qidep*clbfact_dep
           endif
@@ -1292,20 +1293,20 @@ contains
           ! allow ice nucleation if < -15 C and > 5% ice supersaturation
           ! use CELL-AVERAGE values, freezing of vapor
 
-          if ( t(i,k).lt.icenuct .and. supi(i,k).ge.0.05) then
+          if ( t(i,k).lt.icenuct .and. supi(i,k).ge.0.05_rtype) then
             if(.not. log_predictNc) then 
                ! dum = exp(-0.639+0.1296*100.*supi(i,k))*1000.*inv_rho(i,k)  !Meyers et al. (1992)
-               dum = 0.005*exp(0.304*(zerodegc-t(i,k)))*1000.*inv_rho(i,k)   !Cooper (1986)
-               dum = min(dum,100.e3*inv_rho(i,k))
-               N_nuc = max(0.,(dum-nitot(i,k))*odt)
-               if (N_nuc.ge.1.e-20) then
-                  Q_nuc = max(0.,(dum-nitot(i,k))*mi0*odt)
+               dum = 0.005_rtype*exp(0.304_rtype*(zerodegc-t(i,k)))*1000._rtype*inv_rho(i,k)   !Cooper (1986)
+               dum = min(dum,100.e3_rtype*inv_rho(i,k))
+               N_nuc = max(0._rtype,(dum-nitot(i,k))*odt)
+               if (N_nuc.ge.1.e-20_rtype) then
+                  Q_nuc = max(0._rtype,(dum-nitot(i,k))*mi0*odt)
                   qinuc = Q_nuc
                   ninuc = N_nuc
                endif
             else 
             ! Ice nucleation predicted by aerosol scheme 
-               ninuc = max(0., (naai(i,k) - nitot(i,k))*odt)
+               ninuc = max(0._rtype, (naai(i,k) - nitot(i,k))*odt)
                qinuc = ninuc * mi0
             endif 
          endif 
@@ -1337,7 +1338,7 @@ contains
                ! since this is already accounted for by saturation adjustment below
                ncnuc = npccn(i,k)
                if (it.eq.1) then
-                  qcnuc = 0.
+                  qcnuc = 0._rtype
                else
                   !TODO Limit qcnuc so that conditions never become sub-saturated 
                   qcnuc = ncnuc*cons7
@@ -1347,10 +1348,10 @@ contains
            ! for specified Nc, make sure droplets are present if conditions are supersaturated
            ! this is not applied at the first time step, since saturation adjustment is applied at the first step
             dum   = nccnst*inv_rho(i,k)*cons7-qc(i,k)
-            dum   = max(0.,dum)
+            dum   = max(0._rtype,dum)
             dumqvs = qv_sat(t(i,k),pres(i,k),0)
             dqsdt = xxlv(i,k)*dumqvs/(rv*t(i,k)*t(i,k))
-            ab    = 1. + dqsdt*xxlv(i,k)*inv_cp
+            ab    = 1._rtype + dqsdt*xxlv(i,k)*inv_cp
             dum   = min(dum,(qv(i,k)-dumqvs)/ab)  ! limit overdepletion of supersaturation
             qcnuc = dum*odt
          endif
@@ -1366,15 +1367,15 @@ contains
              dumqv  = qv(i,k)
              dumqvs = qv_sat(dumt,pres(i,k),0)
              dums   = dumqv-dumqvs
-             qccon  = dums/(1.+xxlv(i,k)**2*dumqvs/(cp*rv*dumt**2))*odt
-             qccon  = max(0.,qccon)
-             if (qccon.le.1.e-7) qccon = 0.
+             qccon  = dums/(1._rtype+xxlv(i,k)**2*dumqvs/(cp*rv*dumt**2))*odt
+             qccon  = max(0._rtype,qccon)
+             if (qccon.le.1.e-7_rtype) qccon = 0._rtype
           endif
 
           !................
-          ! autoconversion
+          ! autoconversion  ! ASD rtype problem
 
-          qc_not_small: if (qc_incld(i,k).ge.1.e-8) then
+          qc_not_small: if (qc_incld(i,k).ge.1.e-8_rtype) then
 
              if (iparam.eq.1) then
 
@@ -1410,15 +1411,15 @@ contains
 
                 !Khroutdinov and Kogan (2000)
                 dum   = qc_incld(i,k)
-                qcaut = 1350.*dum**2.47*(nc_incld(i,k)*1.e-6*rho(i,k))**(-1.79)
+                qcaut = 1350._rtype*dum**2.47_rtype*(nc_incld(i,k)*1.e-6_rtype*rho(i,k))**(-1.79) ! ASD rtype problem for 1.79 constant
                 ! note: ncautr is change in Nr; ncautc is change in Nc
                 ncautr = qcaut*cons3
                 ncautc = qcaut*nc_incld(i,k)/qc_incld(i,k)
 
              endif
 
-             if (qcaut .eq.0.) ncautc = 0.
-             if (ncautc.eq.0.) qcaut  = 0.
+             if (qcaut .eq.0._rtype) ncautc = 0._rtype
+             if (ncautc.eq.0._rtype) qcaut  = 0._rtype
 
           endif qc_not_small
 
@@ -1429,14 +1430,14 @@ contains
 
              if (iparam.eq.1) then
                 !Seifert and Beheng (2001)
-                ncslf = -kc*(1.e-3*rho(i,k)*qc_incld(i,k))**2*(nu(i,k)+2.)/(nu(i,k)+1.)*         &
-                     1.e+6*inv_rho(i,k)+ncautc
+                ncslf = -kc*(1.e-3_rtype*rho(i,k)*qc_incld(i,k))**2*(nu(i,k)+2._rtype)/(nu(i,k)+1._rtype)*         &
+                     1.e+6_rtype*inv_rho(i,k)+ncautc
              elseif (iparam.eq.2) then
                 !Beheng (994)
-                ncslf = -5.5e+16*inv_rho(i,k)*mu_c(i,k)**(-0.63)*(1.e-3*rho(i,k)*qc_incld(i,k))**2
+                ncslf = -5.5e+16_rtype*inv_rho(i,k)*mu_c(i,k)**(-0.63_rtype)*(1.e-3_rtype*rho(i,k)*qc_incld(i,k))**2
              elseif (iparam.eq.3) then
                 !Khroutdinov and Kogan (2000)
-                ncslf = 0.
+                ncslf = 0._rtype
              endif
 
           endif
@@ -1448,24 +1449,24 @@ contains
 
              if (iparam.eq.1) then
                 !Seifert and Beheng (2001)
-                dum   = 1.-qc_incld(i,k)/(qc_incld(i,k)+qr_incld(i,k))
-                dum1  = (dum/(dum+5.e-4))**4
-                qcacc = kr*rho(i,k)*0.001*qc_incld(i,k)*qr_incld(i,k)*dum1
-                ncacc = qcacc*rho(i,k)*0.001*(nc_incld(i,k)*rho(i,k)*1.e-6)/(qc_incld(i,k)*rho(i,k)*   &
-                     0.001)*1.e+6*inv_rho(i,k)
+                dum   = 1._rtype-qc_incld(i,k)/(qc_incld(i,k)+qr_incld(i,k))
+                dum1  = (dum/(dum+5.e-4_rtype))**4
+                qcacc = kr*rho(i,k)*0.001_rtype*qc_incld(i,k)*qr_incld(i,k)*dum1
+                ncacc = qcacc*rho(i,k)*0.001_rtype*(nc_incld(i,k)*rho(i,k)*1.e-6_rtype)/(qc_incld(i,k)*rho(i,k)*   &
+                     0.001_rtype)*1.e+6_rtype*inv_rho(i,k)
              elseif (iparam.eq.2) then
                 !Beheng (994)
-                qcacc = 6.*rho(i,k)*(qc_incld(i,k)*qr_incld(i,k))
-                ncacc = qcacc*rho(i,k)*1.e-3*(nc_incld(i,k)*rho(i,k)*1.e-6)/(qc_incld(i,k)*rho(i,k)*1.e-3)* &
-                     1.e+6*inv_rho(i,k)
+                qcacc = 6._rtype*rho(i,k)*(qc_incld(i,k)*qr_incld(i,k))
+                ncacc = qcacc*rho(i,k)*1.e-3_rtype*(nc_incld(i,k)*rho(i,k)*1.e-6_rtype)/(qc_incld(i,k)*rho(i,k)*1.e-3_rtype)* &
+                     1.e+6_rtype*inv_rho(i,k)
              elseif (iparam.eq.3) then
                 !Khroutdinov and Kogan (2000)
-                qcacc = 67.*(qc_incld(i,k)*qr_incld(i,k))**1.15
+                qcacc = 67._rtype*(qc_incld(i,k)*qr_incld(i,k))**1.15_rtype
                 ncacc = qcacc*nc_incld(i,k)/qc_incld(i,k)
              endif
 
-             if (qcacc.eq.0.) ncacc = 0.
-             if (ncacc.eq.0.) qcacc = 0.
+             if (qcacc.eq.0._rtype) ncacc = 0._rtype
+             if (ncacc.eq.0._rtype) qcacc = 0._rtype
 
           endif
 
@@ -1476,7 +1477,7 @@ contains
           if (qr_incld(i,k).ge.qsmall) then
 
              ! include breakup
-             dum1 = 280.e-6
+             dum1 = 280.e-6_rtype
 
              ! use mass-mean diameter (do this by using
              ! the old version of lambda w/o mu dependence)
@@ -1486,15 +1487,15 @@ contains
 
              dum2 = (qr_incld(i,k)/(pi*rhow*nr_incld(i,k)))**thrd
              if (dum2.lt.dum1) then
-                dum = 1.
+                dum = 1._rtype
              else if (dum2.ge.dum1) then
-                dum = 2.-exp(2300.*(dum2-dum1))
+                dum = 2._rtype-exp(2300._rtype*(dum2-dum1))
              endif
 
-             if (iparam.eq.1.) then
-                nrslf = dum*kr*1.e-3*qr_incld(i,k)*nr_incld(i,k)*rho(i,k)
+             if (iparam.eq.1) then
+                nrslf = dum*kr*1.e-3_rtype*qr_incld(i,k)*nr_incld(i,k)*rho(i,k)
              elseif (iparam.eq.2 .or. iparam.eq.3) then
-                nrslf = dum*5.78*nr_incld(i,k)*qr_incld(i,k)*rho(i,k)
+                nrslf = dum*5.78_rtype*nr_incld(i,k)*qr_incld(i,k)*rho(i,k)
              endif
 
           endif
@@ -1564,9 +1565,9 @@ contains
           !PMC - might need to rethink above statement since only one category now.
 
           dumqvi = qv_sat(t(i,k),pres(i,k),1)
-          qdep_satadj = (qv(i,k)-dumqvi)/(1.+xxls(i,k)**2*dumqvi/(cp*rv*t(i,k)**2))*odt
-          qidep  = qidep*min(1.,max(0., qdep_satadj)/max(qidep, 1.e-20))
-          qisub  = qisub*min(1.,max(0.,-qdep_satadj)/max(qisub, 1.e-20))
+          qdep_satadj = (qv(i,k)-dumqvi)/(1._rtype+xxls(i,k)**2*dumqvi/(cp*rv*t(i,k)**2))*odt
+          qidep  = qidep*min(1._rtype,max(0._rtype, qdep_satadj)/max(qidep, 1.e-20_rtype))
+          qisub  = qisub*min(1._rtype,max(0._rtype,-qdep_satadj)/max(qisub, 1.e-20_rtype))
           !==
 
           ! vapor -- not needed, since all sinks already have limits imposed and the sum, therefore,
@@ -1575,7 +1576,7 @@ contains
           ! cloud
           sinks   = (qcaut+qcacc+qccol+qcevp+qcheti+qcshd)*dt
           sources = qc(i,k) + (qccon+qcnuc)*dt
-          if (sinks.gt.sources .and. sinks.ge.1.e-20) then
+          if (sinks.gt.sources .and. sinks.ge.1.e-20_rtype) then
              ratio  = sources/sinks
              qcaut  = qcaut*ratio
              qcacc  = qcacc*ratio
@@ -1588,7 +1589,7 @@ contains
           ! rain
           sinks   = (qrevp+qrcol+qrheti)*dt
           sources = qr(i,k) + (qrcon+qcaut+qcacc+qimlt+qcshd)*dt
-          if (sinks.gt.sources .and. sinks.ge.1.e-20) then
+          if (sinks.gt.sources .and. sinks.ge.1.e-20_rtype) then
              ratio  = sources/sinks
              qrevp  = qrevp*ratio
              qrcol  = qrcol*ratio
@@ -1599,7 +1600,7 @@ contains
           sinks   = (qisub+qimlt)*dt
           sources = qitot(i,k) + (qidep+qinuc+qrcol+qccol+  &
                qrheti+qcheti)*dt
-          if (sinks.gt.sources .and. sinks.ge.1.e-20) then
+          if (sinks.gt.sources .and. sinks.ge.1.e-20_rtype) then
              ratio = sources/sinks
              qisub = qisub*ratio
              qimlt = qimlt*ratio
@@ -1647,9 +1648,9 @@ contains
           !PMC nCat deleted interactions_loop
 
 
-          if (qirim(i,k).lt.0.) then
-             qirim(i,k) = 0.
-             birim(i,k) = 0.
+          if (qirim(i,k).lt.0._rtype) then
+             qirim(i,k) = 0._rtype
+             birim(i,k) = 0._rtype
           endif
 
           ! densify under wet growth
@@ -1686,7 +1687,7 @@ contains
              nc(i,k) = nccnst*inv_rho(i,k)
           endif
           if (iparam.eq.1 .or. iparam.eq.2) then
-             nr(i,k) = nr(i,k) + (0.5*ncautc-nrslf-nrevp)*dt
+             nr(i,k) = nr(i,k) + (0.5_rtype*ncautc-nrslf-nrevp)*dt
           else
              nr(i,k) = nr(i,k) + (ncautr-nrslf-nrevp)*dt
           endif
@@ -1705,8 +1706,8 @@ contains
           if (qc(i,k).lt.qsmall) then
              qv(i,k) = qv(i,k) + qc(i,k)
              th(i,k) = th(i,k) - exner(i,k)*qc(i,k)*xxlv(i,k)*inv_cp
-             qc(i,k) = 0.
-             nc(i,k) = 0.
+             qc(i,k) = 0._rtype
+             nc(i,k) = 0._rtype
           else
              log_hydrometeorsPresent = .true.
           endif
@@ -1714,8 +1715,8 @@ contains
           if (qr(i,k).lt.qsmall) then
              qv(i,k) = qv(i,k) + qr(i,k)
              th(i,k) = th(i,k) - exner(i,k)*qr(i,k)*xxlv(i,k)*inv_cp
-             qr(i,k) = 0.
-             nr(i,k) = 0.
+             qr(i,k) = 0._rtype
+             nr(i,k) = 0._rtype
           else
              log_hydrometeorsPresent = .true.
           endif
@@ -1723,10 +1724,10 @@ contains
           if (qitot(i,k).lt.qsmall) then
              qv(i,k) = qv(i,k) + qitot(i,k)
              th(i,k) = th(i,k) - exner(i,k)*qitot(i,k)*xxls(i,k)*inv_cp
-             qitot(i,k) = 0.
-             nitot(i,k) = 0.
-             qirim(i,k) = 0.
-             birim(i,k) = 0.
+             qitot(i,k) = 0._rtype
+             nitot(i,k) = 0._rtype
+             qirim(i,k) = 0._rtype
+             birim(i,k) = 0._rtype
           else
              log_hydrometeorsPresent = .true.
           endif
@@ -1833,7 +1834,7 @@ contains
        qc_present: if (log_qxpresent) then
 
           dt_left   = dt  !time remaining for sedi over full model (mp) time step
-          prt_accum = 0.  !precip rate for individual category
+          prt_accum = 0._rtype  !precip rate for individual category
 
           !find bottom
           do k = kbot,k_qxtop,kdir
@@ -1845,11 +1846,11 @@ contains
 
           two_moment: if (log_predictNc) then  !2-moment cloud:
 
-             substep_sedi_c2: do while (dt_left.gt.1.e-4)
+             substep_sedi_c2: do while (dt_left.gt.1.e-4_rtype)
 
-                Co_max = 0.
-                V_qc = 0.
-                V_nc = 0.
+                Co_max = 0._rtype
+                V_qc = 0._rtype
+                V_nc = 0._rtype
 
                 kloop_sedi_c2: do k = k_qxtop,k_qxbot,-kdir
 
@@ -1858,9 +1859,9 @@ contains
                       call get_cloud_dsd2(qc_incld(i,k),nc_incld(i,k),mu_c(i,k),rho(i,k),nu(i,k),dnu,   &
                            lamc(i,k),lammin,lammax,tmp1,tmp2,lcldm(i,k))
                       nc(i,k) = nc_incld(i,k)*lcldm(i,k)
-                      dum = 1./lamc(i,k)**bcn
-                      V_qc(k) = acn(i,k)*gamma(4.+bcn+mu_c(i,k))*dum/(gamma(mu_c(i,k)+4.))
-                      V_nc(k) = acn(i,k)*gamma(1.+bcn+mu_c(i,k))*dum/(gamma(mu_c(i,k)+1.))
+                      dum = 1._rtype/lamc(i,k)**bcn
+                      V_qc(k) = acn(i,k)*gamma(4._rtype+bcn+mu_c(i,k))*dum/(gamma(mu_c(i,k)+4._rtype))
+                      V_nc(k) = acn(i,k)*gamma(1._rtype+bcn+mu_c(i,k))*dum/(gamma(mu_c(i,k)+1._rtype))
                    endif qc_notsmall_c2
 
                    Co_max = max(Co_max, V_qc(k)*dt_left*inv_dzq(i,k))
@@ -1868,7 +1869,7 @@ contains
                 enddo kloop_sedi_c2
 
                 !-- compute dt_sub
-                tmpint1 = int(Co_max+1.)    !number of substeps remaining if dt_sub were constant
+                tmpint1 = int(Co_max+1._rtype)    !number of substeps remaining if dt_sub were constant
                 dt_sub  = min(dt_left, dt_left/float(tmpint1))
 
                 if (k_qxbot.eq.kbot) then
@@ -1908,10 +1909,10 @@ contains
 
           else  !1-moment cloud:
 
-             substep_sedi_c1: do while (dt_left.gt.1.e-4)
+             substep_sedi_c1: do while (dt_left.gt.1.e-4_rtype)
 
-                Co_max  = 0.
-                V_qc = 0.
+                Co_max  = 0._rtype
+                V_qc = 0._rtype
 
                 kloop_sedi_c1: do k = k_qxtop,k_qxbot,-kdir
 
@@ -1919,15 +1920,15 @@ contains
                       call get_cloud_dsd2(qc_incld(i,k),nc_incld(i,k),mu_c(i,k),rho(i,k),nu(i,k),dnu,   &
                            lamc(i,k),lammin,lammax,tmp1,tmp2,lcldm(i,k))
                       nc(i,k) = nc_incld(i,k)*lcldm(i,k)
-                      dum = 1./lamc(i,k)**bcn
-                      V_qc(k) = acn(i,k)*gamma(4.+bcn+mu_c(i,k))*dum/(gamma(mu_c(i,k)+4.))
+                      dum = 1._rtype/lamc(i,k)**bcn
+                      V_qc(k) = acn(i,k)*gamma(4._rtype+bcn+mu_c(i,k))*dum/(gamma(mu_c(i,k)+4._rtype))
                    endif qc_notsmall_c1
 
                    Co_max = max(Co_max, V_qc(k)*dt_left*inv_dzq(i,k))
 
                 enddo kloop_sedi_c1
 
-                tmpint1 = int(Co_max+1.)    !number of substeps remaining if dt_sub were constant
+                tmpint1 = int(Co_max+1._rtype)    !number of substeps remaining if dt_sub were constant
                 dt_sub  = min(dt_left, dt_left/float(tmpint1))
 
                 if (k_qxbot.eq.kbot) then
@@ -1987,7 +1988,7 @@ contains
        qr_present: if (log_qxpresent) then
 
           dt_left   = dt  !time remaining for sedi over full model (mp) time step
-          prt_accum = 0.  !precip rate for individual category
+          prt_accum = 0._rtype  !precip rate for individual category
 
           !find bottom
           do k = kbot,k_qxtop,kdir
@@ -1997,11 +1998,11 @@ contains
              endif
           enddo
 
-          substep_sedi_r: do while (dt_left.gt.1.e-4)
+          substep_sedi_r: do while (dt_left.gt.1.e-4_rtype)
 
-             Co_max = 0.
-             V_qr = 0.
-             V_nr = 0.
+             Co_max = 0._rtype
+             V_qr = 0._rtype
+             V_nr = 0._rtype
 
              kloop_sedi_r1: do k = k_qxtop,k_qxbot,-kdir
 
@@ -2050,7 +2051,7 @@ contains
              enddo kloop_sedi_r1
 
              !-- compute dt_sub
-             tmpint1 = int(Co_max+1.)    !number of substeps remaining if dt_sub were constant
+             tmpint1 = int(Co_max+1._rtype)    !number of substeps remaining if dt_sub were constant
              dt_sub  = min(dt_left, dt_left/float(tmpint1))
 
              if (k_qxbot.eq.kbot) then
@@ -2122,7 +2123,7 @@ contains
        qi_present: if (log_qxpresent) then
 
           dt_left   = dt  !time remaining for sedi over full model (mp) time step
-          prt_accum = 0.  !precip rate for individual category
+          prt_accum = 0._rtype  !precip rate for individual category
 
           !find bottom
           do k = kbot,k_qxtop,kdir
@@ -2132,11 +2133,11 @@ contains
              endif
           enddo
 
-          substep_sedi_i: do while (dt_left.gt.1.e-4)
+          substep_sedi_i: do while (dt_left.gt.1.e-4_rtype)
 
-             Co_max = 0.
-             V_qit = 0.
-             V_nit = 0.
+             Co_max = 0._rtype
+             V_qit = 0._rtype
+             V_nit = 0._rtype
 
              kloop_sedi_i1: do k = k_qxtop,k_qxbot,-kdir
 
@@ -2173,7 +2174,7 @@ contains
              enddo kloop_sedi_i1
 
              !-- compute dt_sub
-             tmpint1 = int(Co_max+1.)    !number of substeps remaining if dt_sub were constant
+             tmpint1 = int(Co_max+1._rtype)    !number of substeps remaining if dt_sub were constant
              dt_sub  = min(dt_left, dt_left/float(tmpint1))
 
              if (k_qxbot.eq.kbot) then
@@ -2251,11 +2252,11 @@ contains
        k_loop_fz:  do k = kbot,ktop,kdir
 
           ! compute mean-mass ice diameters (estimated; rigorous approach to be implemented later)
-          diam_ice(i,k) = 0.
+          diam_ice(i,k) = 0._rtype
           if (qitot(i,k).ge.qsmall) then
              dum1 = max(nitot(i,k),nsmall)
-             dum2 = 500. !ice density
-             diam_ice(i,k) = ((qitot(i,k)*6.)/(dum1*dum2*pi))**thrd
+             dum2 = 500._rtype !ice density
+             diam_ice(i,k) = ((qitot(i,k)*6._rtype)/(dum1*dum2*pi))**thrd
           endif
 
           if (qc(i,k).ge.qsmall .and. t(i,k).lt.homogfrze) then
@@ -2267,8 +2268,8 @@ contains
              birim(i,k) = birim(i,k) + Q_nuc*inv_rho_rimeMax
              nitot(i,k) = nitot(i,k) + N_nuc
              th(i,k) = th(i,k) + exner(i,k)*Q_nuc*xlf(i,k)*inv_cp
-             qc(i,k) = 0.  != qc(i,k) - Q_nuc
-             nc(i,k) = 0.  != nc(i,k) - N_nuc
+             qc(i,k) = 0._rtype  != qc(i,k) - Q_nuc
+             nc(i,k) = 0._rtype  != nc(i,k) - N_nuc
           endif
 
           if (qr(i,k).ge.qsmall .and. t(i,k).lt.homogfrze) then
@@ -2280,8 +2281,8 @@ contains
              birim(i,k) = birim(i,k) + Q_nuc*inv_rho_rimeMax
              nitot(i,k) = nitot(i,k) + N_nuc
              th(i,k) = th(i,k) + exner(i,k)*Q_nuc*xlf(i,k)*inv_cp
-             qr(i,k) = 0.  ! = qr(i,k) - Q_nuc
-             nr(i,k) = 0.  ! = nr(i,k) - N_nuc
+             qr(i,k) = 0._rtype  ! = qr(i,k) - Q_nuc
+             nr(i,k) = 0._rtype  ! = nr(i,k) - N_nuc
           endif
 
        enddo k_loop_fz
@@ -2298,12 +2299,12 @@ contains
           if (qc(i,k).ge.qsmall) then
              call get_cloud_dsd2(qc(i,k),nc(i,k),mu_c(i,k),rho(i,k),nu(i,k),dnu,lamc(i,k),  &
                   lammin,lammax,tmp1,tmp2,lcldm(i,k))
-             diag_effc(i,k) = 0.5*(mu_c(i,k)+3.)/lamc(i,k)
+             diag_effc(i,k) = 0.5_rtype*(mu_c(i,k)+3._rtype)/lamc(i,k)
           else
              qv(i,k) = qv(i,k)+qc(i,k)
              th(i,k) = th(i,k)-exner(i,k)*qc(i,k)*xxlv(i,k)*inv_cp
-             qc(i,k) = 0.
-             nc(i,k) = 0.
+             qc(i,k) = 0._rtype
+             nc(i,k) = 0._rtype
           endif
 
           ! rain:
@@ -2327,14 +2328,14 @@ contains
              !diag_effr(i,k) = 0.5*(mu_r(i,k)+3.)/lamr(i,k)    (currently not used)
              ! ze_rain(i,k) = n0r(i,k)*720./lamr(i,k)**3/lamr(i,k)**3/lamr(i,k)
              ! non-exponential rain:
-             ze_rain(i,k) = nr(i,k)*(mu_r(i,k)+6.)*(mu_r(i,k)+5.)*(mu_r(i,k)+4.)*           &
-                  (mu_r(i,k)+3.)*(mu_r(i,k)+2.)*(mu_r(i,k)+1.)/lamr(i,k)**6
-             ze_rain(i,k) = max(ze_rain(i,k),1.e-22)
+             ze_rain(i,k) = nr(i,k)*(mu_r(i,k)+6._rtype)*(mu_r(i,k)+5._rtype)*(mu_r(i,k)+4._rtype)*           &
+                  (mu_r(i,k)+3._rtype)*(mu_r(i,k)+2._rtype)*(mu_r(i,k)+1._rtype)/lamr(i,k)**6
+             ze_rain(i,k) = max(ze_rain(i,k),1.e-22_rtype)
           else
              qv(i,k) = qv(i,k)+qr(i,k)
              th(i,k) = th(i,k)-exner(i,k)*qr(i,k)*xxlv(i,k)*inv_cp
-             qr(i,k) = 0.
-             nr(i,k) = 0.
+             qr(i,k) = 0._rtype
+             nr(i,k) = 0._rtype
           endif
 
           ! ice:
@@ -2371,8 +2372,8 @@ contains
 
              !--this should already be done in s/r 'calc_bulkRhoRime'
              if (qirim(i,k).lt.qsmall) then
-                qirim(i,k) = 0.
-                birim(i,k) = 0.
+                qirim(i,k) = 0._rtype
+                birim(i,k) = 0._rtype
              endif
              !==
 
@@ -2382,28 +2383,28 @@ contains
              diag_di(i,k)    = f1pr15
              diag_rhoi(i,k)  = f1pr16
              ! note factor of air density below is to convert from m^6/kg to m^6/m^3
-             ze_ice(i,k) = ze_ice(i,k) + 0.1892*f1pr13*nitot(i,k)*rho(i,k)   ! sum contribution from each ice category (note: 0.1892 = 0.176/0.93)
-             ze_ice(i,k) = max(ze_ice(i,k),1.e-22)
+             ze_ice(i,k) = ze_ice(i,k) + 0.1892_rtype*f1pr13*nitot(i,k)*rho(i,k)   ! sum contribution from each ice category (note: 0.1892 = 0.176/0.93)
+             ze_ice(i,k) = max(ze_ice(i,k),1.e-22_rtype)
 
           else
 
              qv(i,k) = qv(i,k) + qitot(i,k)
              th(i,k) = th(i,k) - exner(i,k)*qitot(i,k)*xxls(i,k)*inv_cp
-             qitot(i,k) = 0.
-             nitot(i,k) = 0.
-             qirim(i,k) = 0.
-             birim(i,k) = 0.
-             diag_di(i,k) = 0.
+             qitot(i,k) = 0._rtype
+             nitot(i,k) = 0._rtype
+             qirim(i,k) = 0._rtype
+             birim(i,k) = 0._rtype
+             diag_di(i,k) = 0._rtype
 
           endif qi_not_small
 
           ! sum ze components and convert to dBZ
-          diag_ze(i,k) = 10.*log10((ze_rain(i,k) + ze_ice(i,k))*1.d+18)
+          diag_ze(i,k) = 10._rtype*log10((ze_rain(i,k) + ze_ice(i,k))*1.e18_rtype)
 
           ! if qr is very small then set Nr to 0 (needs to be done here after call
           ! to ice lookup table because a minimum Nr of nsmall will be set otherwise even if qr=0)
           if (qr(i,k).lt.qsmall) then
-             nr(i,k) = 0.
+             nr(i,k) = 0._rtype
           endif
 
        enddo k_loop_final_diagnostics
@@ -2567,6 +2568,7 @@ contains
 
   !==========================================================================================!
 
+!_rtype
   real(rtype) function polysvp1(T,i_type)
 
     !-------------------------------------------
@@ -2586,18 +2588,18 @@ contains
     ! ice
     real(rtype) a0i,a1i,a2i,a3i,a4i,a5i,a6i,a7i,a8i
     data a0i,a1i,a2i,a3i,a4i,a5i,a6i,a7i,a8i /&
-         6.11147274, 0.503160820, 0.188439774e-1, &
-         0.420895665e-3, 0.615021634e-5,0.602588177e-7, &
-         0.385852041e-9, 0.146898966e-11, 0.252751365e-14/
+         6.11147274_rtype,     0.503160820_rtype,     0.188439774e-1_rtype, &
+         0.420895665e-3_rtype, 0.615021634e-5_rtype,  0.602588177e-7_rtype, &
+         0.385852041e-9_rtype, 0.146898966e-11_rtype, 0.252751365e-14_rtype/
 
     ! liquid
     real(rtype) a0,a1,a2,a3,a4,a5,a6,a7,a8
 
     ! V1.7
     data a0,a1,a2,a3,a4,a5,a6,a7,a8 /&
-         6.11239921, 0.443987641, 0.142986287e-1, &
-         0.264847430e-3, 0.302950461e-5, 0.206739458e-7, &
-         0.640689451e-10,-0.952447341e-13,-0.976195544e-15/
+         6.11239921_rtype,      0.443987641_rtype,     0.142986287e-1_rtype, &
+         0.264847430e-3_rtype,  0.302950461e-5_rtype,  0.206739458e-7_rtype, &
+         0.640689451e-10_rtype,-0.952447341e-13_rtype,-0.976195544e-15_rtype/
     real(rtype) dt
 
     !-------------------------------------------
@@ -2606,10 +2608,10 @@ contains
        ! ICE
 
        !       Flatau formulation:
-       dt       = max(-80.,t-273.16)
+       dt       = max(-80._rtype,t-273.16_rtype)
        polysvp1 = a0i + dt*(a1i+dt*(a2i+dt*(a3i+dt*(a4i+dt*(a5i+dt*(a6i+dt*(a7i+       &
             a8i*dt)))))))
-       polysvp1 = polysvp1*100.
+       polysvp1 = polysvp1*100._rtype
 
        !       Goff-Gratch formulation:
        !        POLYSVP1 = 10.**(-9.09718*(273.16/T-1.)-3.56654*                 &
@@ -2621,9 +2623,9 @@ contains
        ! LIQUID
 
        !       Flatau formulation:
-       dt       = max(-80.,t-273.16)
+       dt       = max(-80._rtype,t-273.16_rtype)
        polysvp1 = a0 + dt*(a1+dt*(a2+dt*(a3+dt*(a4+dt*(a5+dt*(a6+dt*(a7+a8*dt)))))))
-       polysvp1 = polysvp1*100.
+       polysvp1 = polysvp1*100._rtype
 
        !       Goff-Gratch formulation:
        !        POLYSVP1 = 10.**(-7.90298*(373.16/T-1.)+                         &
@@ -2673,7 +2675,7 @@ contains
     ! we are inverting this equation from the lookup table to solve for i:
     ! qitot/nitot=261.7**((i+10)*0.1)*1.e-18
     !dum1 = (log10(qitot/nitot)+18.)/(0.1*log10(261.7))-10.
-    dum1 = (log10(qitot/nitot)+18.)*lookup_table_1a_dum1_c-10. ! For computational efficiency
+    dum1 = (log10(qitot/nitot)+18._rtype)*lookup_table_1a_dum1_c-10._rtype ! For computational efficiency
     dumi = int(dum1)
     ! set limits (to make sure the calculated index doesn't exceed range of lookup table)
     dum1 = min(dum1,real(isize))
@@ -2682,25 +2684,25 @@ contains
     dumi = min(isize-1,dumi)
 
     ! find index for rime mass fraction
-    dum4  = (qirim/qitot)*3. + 1.
+    dum4  = (qirim/qitot)*3._rtype + 1._rtype
     dumii = int(dum4)
     ! set limits
     dum4  = min(dum4,real(rimsize))
-    dum4  = max(dum4,1.)
+    dum4  = max(dum4,1._rtype)
     dumii = max(1,dumii)
     dumii = min(rimsize-1,dumii)
 
     ! find index for bulk rime density
     ! (account for uneven spacing in lookup table for density)
-    if (rhop.le.650.) then
-       dum5 = (rhop-50.)*0.005 + 1.
+    if (rhop.le.650._rtype) then
+       dum5 = (rhop-50._rtype)*0.005_rtype + 1._rtype
     else
-       dum5 =(rhop-650.)*0.004 + 4.
+       dum5 =(rhop-650._rtype)*0.004_rtype + 4._rtype
     endif
     dumjj = int(dum5)
     ! set limits
     dum5  = min(dum5,real(densize))
-    dum5  = max(dum5,1.)
+    dum5  = max(dum5,1._rtype)
     dumjj = max(1,dumjj)
     dumjj = min(densize-1,dumjj)
 
@@ -2733,19 +2735,19 @@ contains
     real_rcollsize = real(rcollsize)
     ! find index for scaled mean rain size
     ! if no rain, then just choose dumj = 1 and do not calculate rain-ice collection processes
-    if (qr.ge.qsmall .and. nr.gt.0.) then
+    if (qr.ge.qsmall .and. nr.gt.0._rtype) then
        ! calculate scaled mean size for consistency with ice lookup table
        dumlr = (qr/(pi*rhow*nr))**thrd
-       dum3  = (log10(1.*dumlr)+5.)*10.70415
+       dum3  = (log10(1._rtype*dumlr)+5._rtype)*10.70415_rtype
        dumj  = int(dum3)
        ! set limits
        dum3  = min(dum3,real_rcollsize)
-       dum3  = max(dum3,1.)
+       dum3  = max(dum3,1._rtype)
        dumj  = max(1,dumj)
        dumj  = min(rcollsize-1,dumj)
     else
        dumj  = 1
-       dum3  = 1.
+       dum3  = 1._rtype
     endif
 
   end subroutine find_lookupTable_indices_1b
@@ -2769,29 +2771,29 @@ contains
     !------------------------------------------------------------------------------------------!
 
     ! find location in scaled mean size space
-    dum1 = (mu_r+1.)/lamr
-    if (dum1.le.195.e-6) then
-       inv_dum3  = 0.1
-       rdumii = (dum1*1.e6+5.)*inv_dum3
-       rdumii = max(rdumii, 1.)
-       rdumii = min(rdumii,20.)
+    dum1 = (mu_r+1._rtype)/lamr
+    if (dum1.le.195.e-6_rtype) then
+       inv_dum3  = 0.1_rtype
+       rdumii = (dum1*1.e6_rtype+5._rtype)*inv_dum3
+       rdumii = max(rdumii, 1._rtype)
+       rdumii = min(rdumii,20._rtype)
        dumii  = int(rdumii)
        dumii  = max(dumii, 1)
        dumii  = min(dumii,20)
-    elseif (dum1.gt.195.e-6) then
-       inv_dum3  = thrd*0.1            !i.e. 1/30
-       rdumii = (dum1*1.e+6-195.)*inv_dum3 + 20.
-       rdumii = max(rdumii, 20.)
-       rdumii = min(rdumii,300.)
+    elseif (dum1.gt.195.e-6_rtype) then
+       inv_dum3  = thrd*0.1_rtype            !i.e. 1/30
+       rdumii = (dum1*1.e+6_rtype-195._rtype)*inv_dum3 + 20._rtype
+       rdumii = max(rdumii, 20._rtype)
+       rdumii = min(rdumii,300._rtype)
        dumii  = int(rdumii)
        dumii  = max(dumii, 20)
        dumii  = min(dumii,299)
     endif
 
     ! find location in mu_r space
-    rdumjj = mu_r+1.
-    rdumjj = max(rdumjj,1.)
-    rdumjj = min(rdumjj,10.)
+    rdumjj = mu_r+1._rtype
+    rdumjj = max(rdumjj,1._rtype)
+    rdumjj = min(rdumjj,10._rtype)
     dumjj  = int(rdumjj)
     dumjj  = max(dumjj,1)
     dumjj  = min(dumjj,9)
@@ -2820,10 +2822,10 @@ contains
 
        ! set minimum nc to prevent floating point error
        nc   = max(nc,nsmall)
-       mu_c = 0.0005714*(nc*1.e-6*rho)+0.2714
-       mu_c = 1./(mu_c**2)-1.
-       mu_c = max(mu_c,2.)
-       mu_c = min(mu_c,15.)
+       mu_c = 0.0005714_rtype*(nc*1.e-6_rtype*rho)+0.2714_rtype
+       mu_c = 1._rtype/(mu_c**2)-1._rtype
+       mu_c = max(mu_c,2._rtype)
+       mu_c = min(mu_c,15._rtype)
 
        ! interpolate for mass distribution spectral shape parameter (for SB warm processes)
        if (iparam.eq.1) then
@@ -2832,28 +2834,28 @@ contains
        endif
 
        ! calculate lamc
-       lamc = (cons1*nc*(mu_c+3.)*(mu_c+2.)*(mu_c+1.)/qc)**thrd
+       lamc = (cons1*nc*(mu_c+3._rtype)*(mu_c+2._rtype)*(mu_c+1._rtype)/qc)**thrd
 
        ! apply lambda limiters
-       lammin = (mu_c+1.)*2.5e+4   ! min: 40 micron mean diameter
-       lammax = (mu_c+1.)*1.e+6    ! max:  1 micron mean diameter
+       lammin = (mu_c+1._rtype)*2.5e+4_rtype   ! min: 40 micron mean diameter
+       lammax = (mu_c+1._rtype)*1.e+6_rtype    ! max:  1 micron mean diameter
 
        if (lamc.lt.lammin) then
           lamc = lammin
-          nc   = 6.*lamc**3*qc/(pi*rhow*(mu_c+3.)*(mu_c+2.)*(mu_c+1.))
+          nc   = 6._rtype*lamc**3*qc/(pi*rhow*(mu_c+3._rtype)*(mu_c+2._rtype)*(mu_c+1._rtype))
        elseif (lamc.gt.lammax) then
           lamc = lammax
-          nc   = 6.*lamc**3*qc/(pi*rhow*(mu_c+3.)*(mu_c+2.)*(mu_c+1.))
+          nc   = 6._rtype*lamc**3*qc/(pi*rhow*(mu_c+3._rtype)*(mu_c+2._rtype)*(mu_c+1._rtype))
        endif
 
-       cdist  = nc*(mu_c+1.)/lamc
-       cdist1 = nc*lcldm/gamma(mu_c+1.)
+       cdist  = nc*(mu_c+1._rtype)/lamc
+       cdist1 = nc*lcldm/gamma(mu_c+1._rtype)
 
     else
 
-       lamc   = 0.
-       cdist  = 0.
-       cdist1 = 0.
+       lamc   = 0._rtype
+       cdist  = 0._rtype
+       cdist1 = 0._rtype
 
     endif
 
@@ -2887,7 +2889,7 @@ contains
        ! find spot in lookup table
        ! (scaled N/q for lookup table parameter space_
        nr      = max(nr,nsmall)
-       inv_dum = (qr/(cons1*nr*6.))**thrd
+       inv_dum = (qr/(cons1*nr*6._rtype))**thrd
 
        ! Apply constant mu_r:  Recall the switch to v4 tables means constant mu_r
        mu_r = mu_r_constant
@@ -2907,27 +2909,27 @@ contains
 !          mu_r = 0.
 !       endif
 
-       lamr   = (cons1*nr*(mu_r+3.)*(mu_r+2)*(mu_r+1.)/(qr))**thrd  ! recalculate slope based on mu_r
-       lammax = (mu_r+1.)*1.e+5   ! check for slope
-       lammin = (mu_r+1.)*1250.   ! set to small value since breakup is explicitly included (mean size 0.8 mm)
+       lamr   = (cons1*nr*(mu_r+3._rtype)*(mu_r+2._rtype)*(mu_r+1._rtype)/(qr))**thrd  ! recalculate slope based on mu_r
+       lammax = (mu_r+1._rtype)*1.e+5_rtype   ! check for slope
+       lammin = (mu_r+1._rtype)*1250._rtype   ! set to small value since breakup is explicitly included (mean size 0.8 mm)
 
        ! apply lambda limiters for rain
        if (lamr.lt.lammin) then
           lamr = lammin
-          nr   = exp(3.*log(lamr)+log(qr)+log(gamma(mu_r+1.))-log(gamma(mu_r+4.)))/(cons1)
+          nr   = exp(3._rtype*log(lamr)+log(qr)+log(gamma(mu_r+1._rtype))-log(gamma(mu_r+4._rtype)))/(cons1)
        elseif (lamr.gt.lammax) then
           lamr = lammax
-          nr   = exp(3.*log(lamr)+log(qr)+log(gamma(mu_r+1.))-log(gamma(mu_r+4.)))/(cons1)
+          nr   = exp(3._rtype*log(lamr)+log(qr)+log(gamma(mu_r+1._rtype))-log(gamma(mu_r+4._rtype)))/(cons1)
        endif
 
-       cdistr  = nr*rcldm/gamma(mu_r+1.)
-       logn0r  = log10(nr)+(mu_r+1.)*log10(lamr)-log10(gamma(mu_r+1)) !note: logn0r is calculated as log10(n0r)
+       cdistr  = nr*rcldm/gamma(mu_r+1._rtype)
+       logn0r  = log10(nr)+(mu_r+1._rtype)*log10(lamr)-log10(gamma(mu_r+1._rtype)) !note: logn0r is calculated as log10(n0r)
 
     else
 
-       lamr   = 0.
-       cdistr = 0.
-       logn0r = 0.
+       lamr   = 0._rtype
+       cdistr = 0._rtype
+       logn0r = 0._rtype
 
     endif
 
@@ -2951,7 +2953,7 @@ contains
 
     !--------------------------------------------------------------------------
 
-    if (bi_rim.ge.1.e-15) then
+    if (bi_rim.ge.1.e-15_rtype) then
        !if (bi_rim.ge.bsmall) then
        rho_rime = qi_rim/bi_rim
        !impose limits on rho_rime;  adjust bi_rim if needed
@@ -2963,21 +2965,21 @@ contains
           bi_rim   = qi_rim/rho_rime
        endif
     else
-       qi_rim   = 0.
-       bi_rim   = 0.
-       rho_rime = 0.
+       qi_rim   = 0._rtype
+       bi_rim   = 0._rtype
+       rho_rime = 0._rtype
     endif
 
     !set upper constraint qi_rim <= qi_tot
-    if (qi_rim.gt.qi_tot .and. rho_rime.gt.0.) then
+    if (qi_rim.gt.qi_tot .and. rho_rime.gt.0._rtype) then
        qi_rim = qi_tot
        bi_rim = qi_rim/rho_rime
     endif
 
     !impose consistency
     if (qi_rim.lt.qsmall) then
-       qi_rim = 0.
-       bi_rim = 0.
+       qi_rim = 0._rtype
+       bi_rim = 0._rtype
     endif
 
 
@@ -3002,9 +3004,9 @@ contains
     !local variables:
     real(rtype)                              :: dum
 
-    if (nitot_local.ge.1.e-20) then
+    if (nitot_local.ge.1.e-20_rtype) then
        dum = max_total_Ni*inv_rho_local/nitot_local
-       nitot_local = nitot_local*min(dum,1.)
+       nitot_local = nitot_local*min(dum,1._rtype)
     endif
 
   end subroutine impose_max_total_Ni
@@ -3033,7 +3035,7 @@ contains
     !------------------
 
     e_pres = polysvp1(t_atm,i_wrt)
-    qv_sat = ep_2*e_pres/max(1.e-3,(p_atm-e_pres))
+    qv_sat = ep_2*e_pres/max(1.e-3_rtype,(p_atm-e_pres))
 
     return
   end function qv_sat
@@ -3066,13 +3068,13 @@ contains
     logical,                intent(in) :: force_abort         !.TRUE. = forces abort if value violation is detected
 
     !Local variables:
-    real(rtype), parameter :: T_low  = 173.
-    real(rtype), parameter :: T_high = 323.
-    real(rtype), parameter :: Q_high = 40.e-3
-    real(rtype), parameter :: N_high = 1.e+20
-    real(rtype), parameter :: B_high = Q_high*1.e-3
-    real(rtype), parameter :: x_high = 1.e+30
-    real(rtype), parameter :: x_low  = 0.
+    real(rtype), parameter :: T_low  = 173._rtype
+    real(rtype), parameter :: T_high = 323._rtype
+    real(rtype), parameter :: Q_high = 40.e-3_rtype
+    real(rtype), parameter :: N_high = 1.e+20_rtype
+    real(rtype), parameter :: B_high = Q_high*1.e-3_rtype
+    real(rtype), parameter :: x_high = 1.e+30_rtype
+    real(rtype), parameter :: x_low  = 0._rtype
     integer         :: k,nk
     logical         :: trap,badvalue_found
 

--- a/components/cam/src/physics/cam/micro_p3.F90
+++ b/components/cam/src/physics/cam/micro_p3.F90
@@ -252,7 +252,6 @@ contains
     ! the lookup table is two dimensional as a function of number-weighted mean size
     ! proportional to qr/Nr and shape parameter mu_r
 
-!ASD rtype problem for mu_r loop
     mu_r_loop: do ii = 1,10   !** change 10 to 9, since range of mu_r is 0-8  CONFIRM
        !mu_r_loop: do ii = 1,9   !** change 10 to 9, since range of mu_r is 0-8
 
@@ -263,57 +262,57 @@ contains
        meansize_loop: do jj = 1,300
 
           if (jj.le.20) then
-             dm = (real(jj)*10.-5.)*1.e-6      ! mean size [m]
+             dm = (real(jj)*10._rtype-5._rtype)*1.e-6_rtype      ! mean size [m]
           elseif (jj.gt.20) then
-             dm = (real(jj-20)*30.+195.)*1.e-6 ! mean size [m]
+             dm = (real(jj-20)*30._rtype+195._rtype)*1.e-6_rtype ! mean size [m]
           endif
 
-          lamr = (mu_r+1)/dm
+          lamr = (mu_r+1._rtype)/dm
 
           ! do numerical integration over PSD
 
-          dum1 = 0. ! numerator,   number-weighted fallspeed
-          dum2 = 0. ! denominator, number-weighted fallspeed
-          dum3 = 0. ! numerator,   mass-weighted fallspeed
-          dum4 = 0. ! denominator, mass-weighted fallspeed
-          dum5 = 0. ! term for ventilation factor in evap
-          dd   = 2.
+          dum1 = 0._rtype ! numerator,   number-weighted fallspeed
+          dum2 = 0._rtype ! denominator, number-weighted fallspeed
+          dum3 = 0._rtype ! numerator,   mass-weighted fallspeed
+          dum4 = 0._rtype ! denominator, mass-weighted fallspeed
+          dum5 = 0._rtype ! term for ventilation factor in evap
+          dd   = 2._rtype
 
           ! loop over PSD to numerically integrate number and mass-weighted mean fallspeeds
           do kk = 1,10000
 
-             dia = (real(kk)*dd-dd*0.5)*1.e-6  ! size bin [m]
-             amg = piov6*997.*dia**3           ! mass [kg]
-             amg = amg*1000.                   ! convert [kg] to [g]
+             dia = (real(kk)*dd-dd*0.5_rtype)*1.e-6_rtype  ! size bin [m]
+             amg = piov6*997._rtype*dia**3           ! mass [kg]
+             amg = amg*1000._rtype                   ! convert [kg] to [g]
 
              !get fallspeed as a function of size [m s-1]
-             if (dia*1.e+6.le.134.43)      then
-                vt = 4.5795e+3*amg**(2.*thrd)
-             elseif (dia*1.e+6.lt.1511.64) then
-                vt = 4.962e+1*amg**thrd
-             elseif (dia*1.e+6.lt.3477.84) then
-                vt = 1.732e+1*amg**sxth
+             if (dia*1.e+6_rtype.le.134.43_rtype)      then
+                vt = 4.5795e+3_rtype*amg**(2._rtype*thrd)
+             elseif (dia*1.e+6_rtype.lt.1511.64_rtype) then
+                vt = 4.962e+1_rtype*amg**thrd
+             elseif (dia*1.e+6_rtype.lt.3477.84_rtype) then
+                vt = 1.732e+1_rtype*amg**sxth
              else
-                vt = 9.17
+                vt = 9.17_rtype
              endif
 
              !note: factor of 4.*mu_r is non-answer changing and only needed to
              !      prevent underflow/overflow errors, same with 3.*mu_r for dum5
-             dum1 = dum1 + vt*10.**(mu_r*log10(dia)+4.*mu_r)*exp(-lamr*dia)*dd*1.e-6
-             dum2 = dum2 + 10.**(mu_r*log10(dia)+4.*mu_r)*exp(-lamr*dia)*dd*1.e-6
-             dum3 = dum3 + vt*10.**((mu_r+3.)*log10(dia)+4.*mu_r)*exp(-lamr*dia)*dd*1.e-6
-             dum4 = dum4 + 10.**((mu_r+3.)*log10(dia)+4.*mu_r)*exp(-lamr*dia)*dd*1.e-6
+             dum1 = dum1 + vt*10._rtype**(mu_r*log10(dia)+4._rtype*mu_r)*exp(-lamr*dia)*dd*1.e-6_rtype
+             dum2 = dum2 + 10._rtype**(mu_r*log10(dia)+4._rtype*mu_r)*exp(-lamr*dia)*dd*1.e-6_rtype
+             dum3 = dum3 + vt*10._rtype**((mu_r+3._rtype)*log10(dia)+4._rtype*mu_r)*exp(-lamr*dia)*dd*1.e-6_rtype
+             dum4 = dum4 + 10._rtype**((mu_r+3._rtype)*log10(dia)+4._rtype*mu_r)*exp(-lamr*dia)*dd*1.e-6_rtype
              dum5 = dum5 + (vt*dia)**0.5*10.**((mu_r+1.)*log10(dia)+3.*mu_r)*exp(-lamr*dia)*dd*1.e-6
 
           enddo ! kk-loop (over PSD)
 
-          dum2 = max(dum2, 1.e-30)  !to prevent divide-by-zero below
-          dum4 = max(dum4, 1.e-30)  !to prevent divide-by-zero below
-          dum5 = max(dum5, 1.e-30)  !to prevent log10-of-zero below
+          dum2 = max(dum2, 1.e-30_rtype)  !to prevent divide-by-zero below
+          dum4 = max(dum4, 1.e-30_rtype)  !to prevent divide-by-zero below
+          dum5 = max(dum5, 1.e-30_rtype)  !to prevent log10-of-zero below
 
           vn_table(jj,ii)    = dum1/dum2
           vm_table(jj,ii)    = dum3/dum4
-          revap_table(jj,ii) = 10.**(log10(dum5)+(mu_r+1.)*log10(lamr)-(3.*mu_r))
+          revap_table(jj,ii) = 10._rtype**(log10(dum5)+(mu_r+1._rtype)*log10(lamr)-(3._rtype*mu_r))
 
        enddo meansize_loop
 
@@ -1373,45 +1372,44 @@ contains
           endif
 
           !................
-          ! autoconversion  ! ASD rtype problem
 
           qc_not_small: if (qc_incld(i,k).ge.1.e-8_rtype) then
 
              if (iparam.eq.1) then
 
                 !Seifert and Beheng (2001)
-                dum   = 1.-qc_incld(i,k)/(qc_incld(i,k)+qr_incld(i,k))
-                dum1  = 600.*dum**0.68*(1.-dum**0.68)**3
+                dum   = 1._rtype-qc_incld(i,k)/(qc_incld(i,k)+qr_incld(i,k))
+                dum1  = 600._rtype*dum**0.68_rtype*(1.-dum**0.68_rtype)**3
                 ! qcaut = kc/(20.*2.6e-7)*(nu(i,k)+2.)*(nu(i,k)+4.)/(nu(i,k)+1.)**2*         &
                 !         (rho(i,k)*qc_incld(i,k)/1000.)**4/(rho(i,k)*nc_incld(i,k)/1.e+6)**2*(1.+       &
                 !         dum1/(1.-dum)**2)*1000.*inv_rho(i,k)
                 ! ncautc = qcaut*2./2.6e-7*1000.
-                qcaut =  kc*1.9230769e-5*(nu(i,k)+2.)*(nu(i,k)+4.)/(nu(i,k)+1.)**2*        &
-                     (rho(i,k)*qc_incld(i,k)*1.e-3)**4/(rho(i,k)*nc_incld(i,k)*1.e-6)**2*(1.+      &
-                     dum1/(1.-dum)**2)*1000.*inv_rho(i,k)
-                ncautc = qcaut*7.6923076e+9
+                qcaut =  kc*1.9230769e-5_rtype*(nu(i,k)+2._rtype)*(nu(i,k)+4._rtype)/(nu(i,k)+1.)**2*        &
+                     (rho(i,k)*qc_incld(i,k)*1.e-3_rtype)**4/(rho(i,k)*nc_incld(i,k)*1.e-6_rtype)**2*(1._rtype+      &
+                     dum1/(1._rtype-dum)**2)*1000._rtype*inv_rho(i,k)
+                ncautc = qcaut*7.6923076e+9_rtype
 
              elseif (iparam.eq.2) then
 
                 !Beheng (1994)
-                if (nc_incld(i,k)*rho(i,k)*1.e-6 .lt. 100.) then
-                   qcaut = 6.e+28*inv_rho(i,k)*mu_c(i,k)**(-1.7)*(1.e-6*rho(i,k)*          &
-                        nc_incld(i,k))**(-3.3)*(1.e-3*rho(i,k)*qc_incld(i,k))**4.7
+                if (nc_incld(i,k)*rho(i,k)*1.e-6_rtype .lt. 100._rtype) then
+                   qcaut = 6.e+28_rtype*inv_rho(i,k)*mu_c(i,k)**(-1.7_rtype)*(1.e-6_rtype*rho(i,k)*          &
+                        nc_incld(i,k))**(-3.3_rtype)*(1.e-3_rtype*rho(i,k)*qc_incld(i,k))**4.7_rtype
                 else
                    !2D interpolation of tabled logarithmic values
-                   dum   = 41.46 + (nc_incld(i,k)*1.e-6*rho(i,k)-100.)*(37.53-41.46)*5.e-3
-                   dum1  = 39.36 + (nc_incld(i,k)*1.e-6*rho(i,k)-100.)*(30.72-39.36)*5.e-3
-                   qcaut = dum+(mu_c(i,k)-5.)*(dum1-dum)*0.1
+                   dum   = 41.46_rtype + (nc_incld(i,k)*1.e-6_rtype*rho(i,k)-100._rtype)*(37.53_rtype-41.46_rtype)*5.e-3_rtype
+                   dum1  = 39.36_rtype + (nc_incld(i,k)*1.e-6_rtype*rho(i,k)-100._rtype)*(30.72_rtype-39.36_rtype)*5.e-3_rtype
+                   qcaut = dum+(mu_c(i,k)-5._rtype)*(dum1-dum)*0.1_rtype
                    ! 1000/rho is for conversion from g cm-3/s to kg/kg
-                   qcaut = exp(qcaut)*(1.e-3*rho(i,k)*qc_incld(i,k))**4.7*1000.*inv_rho(i,k)
+                   qcaut = exp(qcaut)*(1.e-3_rtype*rho(i,k)*qc_incld(i,k))**4.7_rtype*1000._rtype*inv_rho(i,k)
                 endif
-                ncautc = 7.7e+9*qcaut
+                ncautc = 7.7e+9_rtype*qcaut
 
              elseif (iparam.eq.3) then
 
                 !Khroutdinov and Kogan (2000)
                 dum   = qc_incld(i,k)
-                qcaut = 1350._rtype*dum**2.47_rtype*(nc_incld(i,k)*1.e-6_rtype*rho(i,k))**(-1.79) ! ASD rtype problem for 1.79 constant
+                qcaut = 1350._rtype*dum**2.47_rtype*(nc_incld(i,k)*1.e-6_rtype*rho(i,k))**(-1.79_rtype)
                 ! note: ncautr is change in Nr; ncautc is change in Nc
                 ncautr = qcaut*cons3
                 ncautc = qcaut*nc_incld(i,k)/qc_incld(i,k)

--- a/components/cam/src/physics/cam/micro_p3_interface.F90
+++ b/components/cam/src/physics/cam/micro_p3_interface.F90
@@ -1037,7 +1037,7 @@ end subroutine micro_p3_readnl
 
     rd = rair 
     cp = cpair
-    inv_cp = 1./cp 
+    inv_cp = 1._rtype/cp 
     
     ncol = state%ncol
     !==============
@@ -1081,7 +1081,7 @@ end subroutine micro_p3_readnl
     !==============
     ! Note: state%exner is currently defined in a way different than the
     ! traditional definition of exner, so we calculate here.
-    exner(:ncol,:pver) = 1._rtype/((state%pmid(:ncol,:pver)*1.e-5)**(rd*inv_cp))
+    exner(:ncol,:pver) = 1._rtype/((state%pmid(:ncol,:pver)*1.e-5_rtype)**(rd*inv_cp))
     if ( is_first_step() ) then
        th_old(:ncol,:pver)=state%t(:ncol,:pver)*exner(:ncol,:pver)
        qv_old(:ncol,:pver)=state%q(:ncol,:pver,1)
@@ -1478,8 +1478,8 @@ end subroutine micro_p3_readnl
     cvreffliq(:ncol,top_lev:pver) = 9.0_rtype
     cvreffice(:ncol,top_lev:pver) = 37.0_rtype
 
-    reffrain(:,:) = 0.d0
-    reffsnow(:,:) = 0.d0
+    reffrain(:,:) = 0._rtype
+    reffsnow(:,:) = 0._rtype
     reffrain(:ngrdcol,top_lev:pver) = reff_rain(:ngrdcol,top_lev:pver)
     reffsnow(:ngrdcol,top_lev:pver) = 1000._rtype !! dummy value, the choice here impacts the COSP output variable: CFAD_DBZE94_CS.  TODO: Figure out if this is ok, change if needed.
 

--- a/components/cam/src/physics/cam/micro_p3_utils.F90
+++ b/components/cam/src/physics/cam/micro_p3_utils.F90
@@ -32,8 +32,8 @@ module micro_p3_utils
     ! Signaling NaN bit pattern that represents a limiter that's turned off.
     integer(itype), parameter :: limiter_off = int(Z'7FF1111111111111', itype)
 
-    real(rtype), public, parameter :: qsmall = 1.e-14
-    real(rtype), public, parameter :: nsmall = 1.e-16
+    real(rtype), public, parameter :: qsmall = 1.e-14_rtype
+    real(rtype), public, parameter :: nsmall = 1.e-16_rtype
 
     real(rtype) :: xxlv, xxls, xlf
 
@@ -68,7 +68,7 @@ module micro_p3_utils
     ! = 3 Khairoutdinov and Kogan 2000
     integer, public,parameter :: iparam = 3
 
-    real(rtype), parameter, public :: mincld=0.0001
+    real(rtype), parameter, public :: mincld=0.0001_rtype
     real(rtype), parameter, public :: rhosn = 250._rtype  ! bulk density snow
     real(rtype), parameter, public :: rhoi = 500._rtype   ! bulk density ice
     real(rtype), parameter, public :: rhows = 917._rtype  ! bulk density water solid
@@ -162,54 +162,54 @@ end interface var_coef
     masterproc_e3sm = masterproc
 
     ! mathematical/optimization constants
-    thrd  = 1./3.
-    sxth  = 1./6.
+    thrd  = 1./3.  ! ASD rtype problem
+    sxth  = 1./6.  ! ASD rtype problem
     pi_e3sm = pi
     piov3 = pi*thrd
     piov6 = pi*sxth
 
     ! maximum total ice concentration (sum of all categories)
-     max_total_Ni = 500.e+3  !(m)
+     max_total_Ni = 500.e+3_rtype  !(m)
 
     ! droplet concentration (m-3)
-    nccnst = 200.e+6
+    nccnst = 200.e+6_rtype
 
     ! parameters for Seifert and Beheng (2001) autoconversion/accretion
-    kc     = 9.44e+9
-    kr     = 5.78e+3
+    kc     = 9.44e+9_rtype
+    kr     = 5.78e+3_rtype
 
     ! Temperature parameters
     zerodegc  = tmelt 
-    homogfrze = tmelt-40.
-    icenuct   = tmelt-15.
-    rainfrze  = tmelt-4.
+    homogfrze = tmelt-40._rtype
+    icenuct   = tmelt-15._rtype
+    rainfrze  = tmelt-4._rtype
 
     ! physical constants
     cp     = cpair ! specific heat of dry air (J/K/kg) !1005.
-    inv_cp = 1./cp ! inverse of cp
+    inv_cp = 1._rtype/cp ! inverse of cp
     g      = gravit ! Gravity (m/s^2) !9.816
     rd     = rair ! Dry air gas constant     ~ J/K/kg     !287.15
     rv     = rh2o ! Water vapor gas constant ~ J/K/kg     !461.51
     ep_2   = mwh2o/mwdry  ! ratio of molecular mass of water to the molecular mass of dry air !0.622
-    rhosur = 100000./(rd*zerodegc) ! density of air at surface
-    rhosui = 60000./(rd*253.15)
-    ar     = 841.99667 
-    br     = 0.8
-    f1r    = 0.78
-    f2r    = 0.32
-    ecr    = 1.
+    rhosur = 100000._rtype/(rd*zerodegc) ! density of air at surface
+    rhosui = 60000._rtype/(rd*253.15_rtype)
+    ar     = 841.99667_rtype 
+    br     = 0.8_rtype
+    f1r    = 0.78_rtype
+    f2r    = 0.32_rtype
+    ecr    = 1._rtype
     rhow   = rhoh2o ! Density of liquid water (STP) !997.
     cpw    = cpliq  ! specific heat of fresh h2o (J/K/kg) !4218.
-    inv_rhow = 1./rhow  !inverse of (max.) density of liquid water
+    inv_rhow = 1._rtype/rhow  !inverse of (max.) density of liquid water
 
     xxlv = latvap           ! latent heat of vaporization
     xxls = latvap + latice  ! latent heat of sublimation
     xlf  = latice           ! latent heat of fusion
 
     ! limits for rime density [kg m-3]
-    rho_rimeMin     =  50.
-    rho_rimeMax     = 900.
-    inv_rho_rimeMax = 1./rho_rimeMax
+    rho_rimeMin     =  50._rtype
+    rho_rimeMax     = 900._rtype
+    inv_rho_rimeMax =   1._rtype/rho_rimeMax
 
     ! minium allowable prognostic variables
     bsmall = qsmall*inv_rho_rimeMax
@@ -218,21 +218,22 @@ end interface var_coef
     !bimm   = 100.
     !aimm   = 0.66
     ! Barklie and Gokhale (1959)
-    bimm   = 2.
-    aimm   = 0.65
-    rin    = 0.1e-6
-    mi0    = 4.*piov3*900.*1.e-18
+    bimm   = 2._rtype
+    aimm   = 0.65_rtype
+    rin    = 0.1e-6_rtype
+    mi0    = 4._rtype*piov3*900._rtype*1.e-18_rtype
 
-    eci    = 0.5
-    eri    = 1.
-    bcn    = 2.
+    eci    = 0.5_rtype
+    eri    = 1._rtype
+    bcn    = 2._rtype
 
     ! mean size for soft lambda_r limiter [microns]
-    dbrk   = 600.e-6
+    dbrk   = 600.e-6_rtype
     ! ratio of rain number produced to ice number loss from melting
-    nmltratio = 0.2
+    nmltratio = 0.2_rtype
 
-
+! ASD rtype problem for section of consX variables, probably because of the
+! reliance on piov3 and piov6 which is dependent on thrd and sxth (see above).
     cons1 = piov6*rhow
     cons2 = 4.*piov3*rhow
     cons3 = 1./(cons2*(25.e-6)**3)
@@ -242,59 +243,59 @@ end interface var_coef
     cons7 = 4.*piov3*rhow*(1.e-6)**3
 
     ! aerosol/droplet activation parameters
-    mw     = 0.018
-    osm    = 1.
-    vi     = 3.
-    epsm   = 0.9
-    rhoa   = 1777.
-    map    = 0.132
-    ma     = 0.0284
-    rr     = 8.3187
+    mw     = 0.018_rtype
+    osm    = 1._rtype
+    vi     = 3._rtype
+    epsm   = 0.9_rtype
+    rhoa   = 1777._rtype
+    map    = 0.132_rtype
+    ma     = 0.0284_rtype
+    rr     = 8.3187_rtype
     bact   = vi*osm*epsm*mw*rhoa/(map*rhow)
     ! inv_bact = (map*rhow)/(vi*osm*epsm*mw*rhoa)    *** to replace /bact **
 
     ! mode 1
-    inv_rm1 = 2.e+7           ! inverse aerosol mean size (m-1)
-    sig1    = 2.0             ! aerosol standard deviation
-    nanew1  = 300.e6          ! aerosol number mixing ratio (kg-1)
-    f11     = 0.5*exp(2.5*(log(sig1))**2)
-    f21     = 1. + 0.25*log(sig1)
+    inv_rm1 = 2.e+7_rtype           ! inverse aerosol mean size (m-1)
+    sig1    = 2.0_rtype             ! aerosol standard deviation
+    nanew1  = 300.e6_rtype          ! aerosol number mixing ratio (kg-1)
+    f11     = 0.5_rtype*exp(2.5_rtype*(log(sig1))**2)
+    f21     = 1._rtype + 0.25_rtype*log(sig1)
 
     ! note: currently only set for a single mode, droplet activation code needs to
     !       be modified to include the second mode
     ! mode 2
-    inv_rm2 = 7.6923076e+5    ! inverse aerosol mean size (m-1)
-    sig2    = 2.5             ! aerosol standard deviation
-    nanew2  = 0.              ! aerosol number mixing ratio (kg-1)
-    f12     = 0.5*exp(2.5*(log(sig2))**2)
-    f22     = 1. + 0.25*log(sig2)
+    inv_rm2 = 7.6923076e+5_rtype    ! inverse aerosol mean size (m-1)
+    sig2    = 2.5_rtype             ! aerosol standard deviation
+    nanew2  = 0._rtype              ! aerosol number mixing ratio (kg-1)
+    f12     = 0.5_rtype*exp(2.5_rtype*(log(sig2))**2)
+    f22     = 1._rtype + 0.25_rtype*log(sig2)
 
     ! droplet spectral shape parameter for mass spectra, used for Seifert and Beheng (2001)
     ! warm rain autoconversion/accretion option only (iparam = 1)
 !    allocate(dnu(16))
-    dnu(1)  =  0.000
-    dnu(2)  = -0.557
-    dnu(3)  = -0.430
-    dnu(4)  = -0.307
-    dnu(5)  = -0.186
-    dnu(6)  = -0.067
-    dnu(7)  = -0.050
-    dnu(8)  = -0.167
-    dnu(9)  = -0.282
-    dnu(10) = -0.397
-    dnu(11) = -0.512
-    dnu(12) = -0.626
-    dnu(13) = -0.739
-    dnu(14) = -0.853
-    dnu(15) = -0.966
-    dnu(16) = -0.966
+    dnu(1)  =  0.000_rtype
+    dnu(2)  = -0.557_rtype
+    dnu(3)  = -0.430_rtype
+    dnu(4)  = -0.307_rtype
+    dnu(5)  = -0.186_rtype
+    dnu(6)  = -0.067_rtype
+    dnu(7)  = -0.050_rtype
+    dnu(8)  = -0.167_rtype
+    dnu(9)  = -0.282_rtype
+    dnu(10) = -0.397_rtype
+    dnu(11) = -0.512_rtype
+    dnu(12) = -0.626_rtype
+    dnu(13) = -0.739_rtype
+    dnu(14) = -0.853_rtype
+    dnu(15) = -0.966_rtype
+    dnu(16) = -0.966_rtype
 
     ! calibration factors for ice deposition and sublimation
     !   These are adjustable ad hoc factors used to increase or decrease deposition and/or
     !   sublimation rates.  The representation of the ice capacitances are highly simplified
     !   and the appropriate values in the diffusional growth equation are uncertain.
-    clbfact_dep = 1.
-    clbfact_sub = 1.
+    clbfact_dep = 1._rtype
+    clbfact_sub = 1._rtype
 
     ! Don't specify lambda bounds for cloud liquid, as they are determined by
     ! pgam dynamically.
@@ -303,7 +304,7 @@ end interface var_coef
   
     ! Mean ice diameter can not grow bigger than twice the autoconversion
     ! threshold for snow.
-    ice_lambda_bounds = 1._rtype/[2.*400.e-6_rtype, 10.e-6_rtype] !! dcs 400.e-6
+    ice_lambda_bounds = 1._rtype/[2._rtype*400.e-6_rtype, 10.e-6_rtype] !! dcs 400.e-6
     micro_ice_props = MicroHydrometeorProps(rhoi, dsph, &
          ice_lambda_bounds, min_mean_mass_ice)
   
@@ -353,34 +354,34 @@ end interface var_coef
 
        if (qc.ge.qsmall) then
           qc_incld = qc*inv_lcldm
-          nc_incld = max(nc*inv_lcldm,0.)
+          nc_incld = max(nc*inv_lcldm,0._rtype)
           !AaronDonahue, kai has something about if nccons then nc=ncnst/rho
        else
-          qc_incld = 0.
-          nc_incld = 0.
+          qc_incld = 0._rtype
+          nc_incld = 0._rtype
        end if 
        if (qitot.ge.qsmall) then
           qitot_incld = qitot*inv_icldm
-          nitot_incld = max(nitot*inv_icldm,0.)
+          nitot_incld = max(nitot*inv_icldm,0._rtype)
           !AaronDonahue, kai has something about if nicons then ni=ninst/rho
        else
-          qitot_incld = 0.
-          nitot_incld = 0.
+          qitot_incld = 0._rtype
+          nitot_incld = 0._rtype
        end if 
        if (qirim.ge.qsmall.and.qitot.ge.qsmall) then
           qirim_incld = qirim*inv_icldm
-          birim_incld = max(birim*inv_lcldm,0.)
+          birim_incld = max(birim*inv_lcldm,0._rtype)
        else
-          qirim_incld = 0.
-          birim_incld = 0.
+          qirim_incld = 0._rtype
+          birim_incld = 0._rtype
        end if 
        if (qr.ge.qsmall) then
           qr_incld = qr*inv_rcldm
-          nr_incld = max(nr*inv_rcldm,0.)
+          nr_incld = max(nr*inv_rcldm,0._rtype)
           !AaronDonahue, kai has something about if nccons then nc=ncnst/rho
        else
-          qr_incld = 0.
-          nr_incld = 0.
+          qr_incld = 0._rtype
+          nr_incld = 0._rtype
        end if
        if (qc_incld.gt.incloud_limit .or.qitot_incld.gt.incloud_limit .or. qr_incld.gt.precip_limit .or.birim_incld.gt.incloud_limit) then
 !          write(errmsg,'(a3,i4,3(a5,1x,e16.8,1x))') 'k: ', k, ', qc:',qc_incld, ', qi:',qitot_incld,', qr:',qr_incld

--- a/components/cam/src/physics/cam/micro_p3_utils.F90
+++ b/components/cam/src/physics/cam/micro_p3_utils.F90
@@ -162,8 +162,8 @@ end interface var_coef
     masterproc_e3sm = masterproc
 
     ! mathematical/optimization constants
-    thrd  = 1./3.  ! ASD rtype problem
-    sxth  = 1./6.  ! ASD rtype problem
+    thrd  = 1._rtype/3._rtype
+    sxth  = 1._rtype/6._rtype 
     pi_e3sm = pi
     piov3 = pi*thrd
     piov6 = pi*sxth
@@ -232,15 +232,13 @@ end interface var_coef
     ! ratio of rain number produced to ice number loss from melting
     nmltratio = 0.2_rtype
 
-! ASD rtype problem for section of consX variables, probably because of the
-! reliance on piov3 and piov6 which is dependent on thrd and sxth (see above).
     cons1 = piov6*rhow
-    cons2 = 4.*piov3*rhow
-    cons3 = 1./(cons2*(25.e-6)**3)
-    cons4 = 1./(dbrk**3*pi*rhow)
+    cons2 = 4._rtype*piov3*rhow
+    cons3 = 1._rtype/(cons2*(25.e-6_rtype)**3)
+    cons4 = 1._rtype/(dbrk**3*pi*rhow)
     cons5 = piov6*bimm
     cons6 = piov6**2*rhow*bimm
-    cons7 = 4.*piov3*rhow*(1.e-6)**3
+    cons7 = 4._rtype*piov3*rhow*(1.e-6_rtype)**3
 
     ! aerosol/droplet activation parameters
     mw     = 0.018_rtype


### PR DESCRIPTION
This commit is non-BFB in that prior code did not enforce precision everywhere
so some of the values may have changed.  B4B consistentcy was checked by forcing
a baseline version of the model to be fully double precision using the intel
fortran compiler option '-fpconstant', then making the changes and comparing.

Thus, when all constants are set to be consistent in terms of precision this commit
is BFB.

Finally, there was a handful of constants that were non-BFB even when precision was
enforced by compiler flag.  These haven't been changed in this commit and will be
addressed in a later commit.  These are clearly marked by comments using the line
"rtype problem".